### PR TITLE
Fix Apple Maps short links

### DIFF
--- a/app/src/main/java/page/ooooo/geoshare/lib/converters/AppleMapsUrlConverter.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/converters/AppleMapsUrlConverter.kt
@@ -50,11 +50,11 @@ class AppleMapsUrlConverter(
         Pattern.compile("""<meta property="place:location:longitude" content="$lonRegex""""),
     )
 
-    override fun isSupportedUrl(url: URL): Boolean = isFullUrl(url) || isShortUrl(url)
+    override fun isSupportedUrl(url: URL): Boolean =
+        fullUrlPattern.matcher(url.toString()).matches() || shortUrlPattern.matcher(url.toString()).matches()
 
-    private fun isFullUrl(url: URL): Boolean = fullUrlPattern.matcher(url.toString()).matches()
-
-    override fun isShortUrl(url: URL): Boolean = shortUrlPattern.matcher(url.toString()).matches()
+    override fun isShortUrl(url: URL): Boolean =
+        false // Treat all URLs as full URLs, because Apple Maps short URLs cannot be unshortened using a HEAD request.
 
     override fun parseUrl(url: URL): ParseUrlResult? {
         val position = Position()
@@ -85,6 +85,8 @@ class AppleMapsUrlConverter(
         } else if (position.q != null) {
             log.i(null, "Apple Maps URL converted but it contains only query $url > $position")
             ParseUrlResult.Parsed(position)
+        } else if (shortUrlPattern.matcher(url.toString()).matches()) {
+            ParseUrlResult.RequiresHtmlParsing()
         } else {
             log.i(null, "Apple Maps URL does not contain coordinates or query or place id $url")
             null

--- a/app/src/test/java/page/ooooo/geoshare/AppleMapsUrlConverterTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/AppleMapsUrlConverterTest.kt
@@ -35,15 +35,20 @@ class AppleMapsUrlConverterTest {
     }
 
     @Test
+    fun isSupportedUrl_supportedUrl() {
+        assertTrue(appleMapsUrlConverter.isSupportedUrl(URL("https://maps.apple.com/?ll=50.894967,4.341626")))
+    }
+
+    @Test
+    fun isSupportedUrl_shortUrl() {
+        assertTrue(appleMapsUrlConverter.isSupportedUrl(URL("https://maps.apple/p/7E-Brjrk_THN14")))
+    }
+
+    @Test
     fun parseUrl_noPathOrKnownUrlQueryParams() {
         assertNull(appleMapsUrlConverter.parseUrl(URL("https://maps.apple.com")))
         assertNull(appleMapsUrlConverter.parseUrl(URL("https://maps.apple.com/")))
         assertNull(appleMapsUrlConverter.parseUrl(URL("https://maps.apple.com/?spam=1")))
-    }
-
-    @Test
-    fun isSupportedUrl_supportedUrl() {
-        assertTrue(appleMapsUrlConverter.isSupportedUrl(URL("https://maps.apple.com/?ll=50.894967,4.341626")))
     }
 
     @Test
@@ -153,6 +158,11 @@ class AppleMapsUrlConverterTest {
     }
 
     @Test
+    fun parseUrl_shortLink() {
+        assertTrue(appleMapsUrlConverter.parseUrl(URL("https://maps.apple/p/7E-Brjrk_THN14")) is ParseUrlResult.RequiresHtmlParsing)
+    }
+
+    @Test
     fun parseHtml_success() {
         val html =
             this.javaClass.classLoader!!.getResource("I3B04EDEB21D5F86.html")!!
@@ -169,12 +179,7 @@ class AppleMapsUrlConverterTest {
     }
 
     @Test
-    fun isShortUrl_mapsApple_returnsTrue() {
-        assertTrue(appleMapsUrlConverter.isShortUrl(URL("https://maps.apple/p/7E-Brjrk_THN14")))
-    }
-
-    @Test
-    fun isShortUrl_mapsAppleCom_returnsFalse() {
-        assertFalse(appleMapsUrlConverter.isShortUrl(URL("https://maps.apple.com/?ll=50.894967,4.341626")))
+    fun isShortUrl_alwaysReturnsFalse() {
+        assertFalse(appleMapsUrlConverter.isShortUrl(URL("https://maps.apple/p/7E-Brjrk_THN14")))
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -1,6 +1,7 @@
 - Replaced the default Android share menu with a custom interface that includes additional actions.
 - Replaced the "Copy geo:" share target with a button in the custom share interface.
 - Changed the resulting geo: URI format to show a pin in Google Maps.
+- Fixed support for Apple Maps short links.
 - Added support for links shared from GMaps VW.
 - Added button to open the original link unchanged (passthrough).
 - Added menu to copy coordinates in various formats including a magicearth: URI.


### PR DESCRIPTION
Currently all Apple Maps short links return error 404, because we try to unshorten them using a HEAD request. HEAD requests don't seem supported by Apple Maps, so let's just consider all Apple Maps links as full links, download their HTML and parse coordinates from the HTML document.

Fixes: #84