### PR TITLE
Don't URL-encode comma in geo: URI pin

### DIFF
--- a/app/src/androidTest/java/page/ooooo/geoshare/ConversionActivityBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/ConversionActivityBehaviorTest.kt
@@ -264,6 +264,7 @@ class ConversionActivityBehaviorTest : BaseActivityBehaviorTest() {
         waitAndDismissDialogAndAssertItIsClosed(parseHtmlPermissionDialogSelector)
 
         // Shows location search
+        @Suppress("SpellCheckingInspection")
         waitAndAssertPositionIsVisible(Position(q = "Hermannstr. 30, Berlin"))
 
         // Share another Google Maps place link with the app
@@ -282,12 +283,14 @@ class ConversionActivityBehaviorTest : BaseActivityBehaviorTest() {
         waitAndDismissDialogAndAssertItIsClosed(By.res("geoShareParseHtmlPermissionDialog"), doNotAsk = true)
 
         // Shows location search
+        @Suppress("SpellCheckingInspection")
         waitAndAssertPositionIsVisible(Position(q = "Hermannstr. 40, Berlin"))
 
         // Share another Google Maps place link with the app
         shareUri("https://www.google.com/maps/place/Hermannstr.+41,+Berlin/")
 
         // Shows location search
+        @Suppress("SpellCheckingInspection")
         waitAndAssertPositionIsVisible(Position(q = "Hermannstr. 41, Berlin"))
     }
 

--- a/app/src/main/java/page/ooooo/geoshare/lib/Uri.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/Uri.kt
@@ -69,7 +69,7 @@ data class Uri(
                 host = host,
                 path = uriQuote.decode(path),
                 queryParams = parseQueryParams(query, uriQuote),
-                fragment = fragment,
+                fragment = uriQuote.decode(fragment),
                 uriQuote = uriQuote,
             )
         }

--- a/app/src/main/java/page/ooooo/geoshare/lib/Uri.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/Uri.kt
@@ -120,8 +120,9 @@ data class Uri(
         }.toString()
     )
 
-    private fun formatQueryParams(): String =
-        queryParams.map { "${it.key}=${uriQuote.encode(it.value.replace('+', ' '))}" }.joinToString("&")
+    private fun formatQueryParams(): String = queryParams.map {
+        "${it.key}=${uriQuote.encode(it.value.replace('+', ' '), allow = ",")}"
+    }.joinToString("&")
 
     override fun toString() = StringBuilder().apply {
         if (scheme.isNotEmpty()) {

--- a/app/src/main/java/page/ooooo/geoshare/lib/UriQuote.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/UriQuote.kt
@@ -17,14 +17,17 @@ class DefaultUriQuote : UriQuote {
 }
 
 class FakeUriQuote : UriQuote {
-    override fun encode(s: String): String =
-        URLEncoder.encode(s, "utf-8").replace("+", "%20")
+    override fun encode(s: String): String = URLEncoder.encode(s, "utf-8").replace("+", "%20")
 
-    override fun encode(s: String, allow: String): String =
-        allow.fold(URLEncoder.encode(s, "utf-8")) { res, char ->
-            res.replace(URLEncoder.encode(char.toString(), "utf-8"), char.toString())
+    override fun encode(s: String, allow: String): String = allow.fold(URLEncoder.encode(s, "utf-8")) { res, char ->
+        res.replace(URLEncoder.encode(char.toString(), "utf-8"), char.toString())
+    }.let {
+        if ('+' in allow) {
+            it
+        } else {
+            it.replace("+", "%20")
         }
+    }
 
-    override fun decode(s: String): String =
-        URLDecoder.decode(s, "utf-8").replace("%20", " ")
+    override fun decode(s: String): String = URLDecoder.decode(s, "utf-8")
 }

--- a/app/src/main/java/page/ooooo/geoshare/lib/converters/OpenStreetMapUrlConverter.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/converters/OpenStreetMapUrlConverter.kt
@@ -11,6 +11,6 @@ class OpenStreetMapUrlConverter : UrlConverter.WithUriPattern {
     override val uriPattern: Pattern = Pattern.compile("""(https?://)?(www\.)?openstreetmap\.org/\S+""")
 
     override val conversionUriPattern = uriPattern {
-        fragment(PositionRegex("""map(=|%3D)$Z(/|%2F)$LAT(/|%2F)$LON.*"""))
+        fragment(PositionRegex("""map=$Z/$LAT/$LON.*"""))
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/PositionTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/PositionTest.kt
@@ -27,7 +27,7 @@ class PositionTest {
     @Test
     fun toAppleMapsUriString_whenUriHasCoordinatesAndZoom_returnsCoordinatesAndZoom() {
         assertEquals(
-            "https://maps.apple.com/?ll=50.123456%2C-11.123456&z=3.4",
+            "https://maps.apple.com/?ll=50.123456,-11.123456&z=3.4",
             Position("50.123456", "-11.123456", z = "3.4").toAppleMapsUriString(uriQuote),
         )
     }
@@ -35,7 +35,7 @@ class PositionTest {
     @Test
     fun toAppleMapsUriString_whenUriHasCoordinatesAndQueryAndZoom_returnsCoordinatesAndZoom() {
         assertEquals(
-            "https://maps.apple.com/?ll=50.123456%2C-11.123456&z=3.4",
+            "https://maps.apple.com/?ll=50.123456,-11.123456&z=3.4",
             Position("50.123456", "-11.123456", q = "foo bar", z = "3.4").toAppleMapsUriString(uriQuote),
         )
     }
@@ -51,7 +51,7 @@ class PositionTest {
     @Test
     fun toGoogleMapsUriString_whenUriHasCoordinatesAndZoom_returnsCoordinatesAsQueryAndZoom() {
         assertEquals(
-            "https://www.google.com/maps?q=50.123456%2C-11.123456&z=3.4",
+            "https://www.google.com/maps?q=50.123456,-11.123456&z=3.4",
             Position("50.123456", "-11.123456", z = "3.4").toGoogleMapsUriString(uriQuote),
         )
     }
@@ -67,7 +67,7 @@ class PositionTest {
     @Test
     fun toGoogleMapsUriString_whenUriHasCoordinatesAndQueryAndZoom_returnsCoordinatesAndZoom() {
         assertEquals(
-            "https://www.google.com/maps?q=50.123456%2C-11.123456&z=3.4",
+            "https://www.google.com/maps?q=50.123456,-11.123456&z=3.4",
             Position("50.123456", "-11.123456", q = "foo bar", z = "3.4").toGoogleMapsUriString(uriQuote),
         )
     }

--- a/app/src/test/java/page/ooooo/geoshare/UriQuoteTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/UriQuoteTest.kt
@@ -1,0 +1,28 @@
+package page.ooooo.geoshare
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import page.ooooo.geoshare.lib.FakeUriQuote
+
+class UriQuoteTest {
+    val uriQuote = FakeUriQuote()
+
+    @Test
+    fun encode_encodesSpace() {
+        assertEquals("foo%20bar", uriQuote.encode("foo bar"))
+    }
+
+    @Test
+    fun encode_encodesPlus() {
+        @Suppress("SpellCheckingInspection")
+        assertEquals("foo%2Bbar", uriQuote.encode("foo+bar"))
+    }
+
+    @Test
+    fun encode_doesNotEncodeAllowedChars() {
+        assertEquals(
+            "foo%20bar,baz/spam=spam",
+            uriQuote.encode("foo bar,baz/spam=spam", allow = ",/="),
+        )
+    }
+}

--- a/app/src/test/java/page/ooooo/geoshare/UriTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/UriTest.kt
@@ -445,6 +445,15 @@ class UriTest {
     }
 
     @Test
+    fun toString_doesNotEncodeCommaInQuery() {
+        val uriString = "geo:52.3675734,4.9041389?q=52.3675734%2C4.9041389"
+        assertEquals(
+            "geo:52.3675734,4.9041389?q=52.3675734,4.9041389",
+            Uri.parse(uriString, uriQuote).toString()
+        )
+    }
+
+    @Test
     fun toUrl_addsHttpsSchemeIfNecessary() {
         assertEquals("https://foo/bar", Uri.parse("https://foo/bar", uriQuote).toUrl().toString())
         assertEquals("https://foo", Uri.parse("https://foo", uriQuote).toUrl().toString())


### PR DESCRIPTION
To fix Threema.

And refactor URL-decoding of URI fragment.

Fixes: #140