### PR TITLE
Point out how Geo Share may be considered more private

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ a geo: URI:
    creation of the geo: link.
 
 To permanently allow or deny connecting to the map service instead of always
-asking (the default), go to the app’s Preferences.
+asking (the default), go to the app’s Preferences. Note that even with the need for Geo Share to connect to the internet in such situations, it may be considered a more private and secure approach as it wouldn't allow JavaScript-based fingerprinting or code execution.
 
 ## Reporting issues
 


### PR DESCRIPTION
when getting data from links through the internet