### PR TITLE
Fix duplicate 'seconds' resource key

### DIFF
--- a/app/src/main/java/page/ooooo/geoshare/data/local/preferences/UserPreferences.kt
+++ b/app/src/main/java/page/ooooo/geoshare/data/local/preferences/UserPreferences.kt
@@ -160,7 +160,7 @@ abstract class DurationUserPreference : NumberUserPreference<Duration>() {
     override fun deserialize(value: String?) = value?.toIntOrNull()?.coerceIn(minValue, maxValue)?.seconds ?: default
 
     @Composable
-    override fun suffix() = stringResource(R.string.seconds)
+    override fun suffix() = stringResource(R.string.seconds_unit)
 
     @Composable
     override fun ValueLabel(values: UserPreferencesValues) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,7 +179,7 @@
     <string name="network_exception_socket_timeout" translatable="false">socket timeout</string>
     <string name="network_exception_unknown" translatable="false">unknown error</string>
     <string name="network_exception_unresolved_address" translatable="false">unresolved address</string>
-    <string name="seconds">seconds</string>
+    <string name="seconds_unit">seconds</string>
     <string name="reset">reset</string>
     <plurals name="seconds">
         <item quantity="one">%1$d second</item>


### PR DESCRIPTION
Otherwise Weblate fails to load both keys.