### PR TITLE
Fix copy button not visible on result screen

### DIFF
--- a/app/src/main/java/page/ooooo/geoshare/ui/components/ResultSuccessCoordinates.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/components/ResultSuccessCoordinates.kt
@@ -77,15 +77,18 @@ fun ResultSuccessCoordinates(
                 SelectionContainer {
                     Text(
                         text,
-                        Modifier.testTag("geoShareResultSuccessLastPointCoordinates"),
+                        Modifier
+                            .weight(1f)
+                            .testTag("geoShareResultSuccessLastPointCoordinates"),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                 }
             } ?: Text(
                 stringResource(R.string.conversion_succeeded_description_q_only),
                 Modifier
-                    .testTag("geoShareResultSuccessLastPointDescription")
-                    .fillMaxWidth(),
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .testTag("geoShareResultSuccessLastPointDescription"),
                 fontStyle = FontStyle.Italic,
                 style = MaterialTheme.typography.bodySmall.copy(
                     lineBreak = LineBreak.Paragraph,


### PR DESCRIPTION
When description that only place name was extracted is visible.