### PR TITLE
Handle OpenStreetMap URIs with query strings

### DIFF
--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/OpenStreetMapInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/OpenStreetMapInputBehaviorTest.kt
@@ -15,6 +15,14 @@ class OpenStreetMapInputBehaviorTest : InputBehaviorTest {
             WGS84Point(51.49, -0.13, z = 16.0, source = Source.MAP_CENTER),
             "https://www.openstreetmap.org/#map=16/51.49/-0.13",
         )
+        testUri(
+            WGS84Point(51.49, -0.13, z = 16.0, source = Source.URI),
+            "https://www.openstreetmap.org/?lat=51.49&lon=-0.13&zoom=16",
+        )
+        testUri(
+            WGS84Point(51.49, -0.13, source = Source.URI),
+            "https://www.openstreetmap.org/?lat=51.49&lon=-0.13",
+        )
 
         // Directions
         testUri(

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/OpenStreetMapInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/OpenStreetMapInput.kt
@@ -9,6 +9,7 @@ import page.ooooo.geoshare.R
 import page.ooooo.geoshare.lib.ILog
 import page.ooooo.geoshare.lib.Uri
 import page.ooooo.geoshare.lib.UriQuote
+import page.ooooo.geoshare.lib.extensions.doubleGroupOrNull
 import page.ooooo.geoshare.lib.extensions.groupOrNull
 import page.ooooo.geoshare.lib.extensions.matchEntire
 import page.ooooo.geoshare.lib.extensions.toLatLonPoint
@@ -55,6 +56,16 @@ object OpenStreetMapInput : HtmlInput, Input.HasRandomUri {
             Regex("""map=$Z/$LAT/$LON.*""").matchEntire(fragment)?.toZLatLonPoint(Source.MAP_CENTER)?.let {
                 points = persistentListOf(WGS84Point(it))
                 return@run
+            }
+
+            // Coordinates
+            // https://www.openstreetmap.org/?lat={lat}&lon={lon}&zoom={z}
+            LAT_PATTERN.matchEntire(queryParams["lat"])?.doubleGroupOrNull()?.let { lat ->
+                LON_PATTERN.matchEntire(queryParams["lon"])?.doubleGroupOrNull()?.let { lon ->
+                    val z = Z_PATTERN.matchEntire(queryParams["z"])?.doubleGroupOrNull()
+                    points = persistentListOf(WGS84Point(lat, lon, z, source = Source.URI))
+                    return@run
+                }
             }
 
             // Directions


### PR DESCRIPTION
Discovered this URI being used by Joplin, which currently shows an error in Geo Share as the domain is recognised but not the parameter format.

Example: https://www.openstreetmap.org/?lat=51.5007042&lon=-0.1245721&zoom=17

---

PS. I initially had trouble getting this project to open Android Studio, and eventually figured out that the `.idea` directory is committed and contains device-specific setup (like a hardcoded UNIX path to Gradle) -- `.idea` should probably be removed from the repo and added to `.gitignore`; possibly the top-level `gradle` directory too.