### PR TITLE
Fix pin display when opening Cartes IGN

### DIFF
--- a/app/src/main/java/page/ooooo/geoshare/data/OutputRepository.kt
+++ b/app/src/main/java/page/ooooo/geoshare/data/OutputRepository.kt
@@ -16,6 +16,7 @@ import page.ooooo.geoshare.data.local.preferences.CopyLinkNavigationMagicEarthUr
 import page.ooooo.geoshare.data.local.preferences.CopyLinkStreetViewGoogleUriAutomation
 import page.ooooo.geoshare.data.local.preferences.CopyLinkUriAutomation
 import page.ooooo.geoshare.data.local.preferences.NoopAutomation
+import page.ooooo.geoshare.data.local.preferences.OpenDisplayCartesIGNUrlAutomation
 import page.ooooo.geoshare.data.local.preferences.OpenDisplayGeoUriAutomation
 import page.ooooo.geoshare.data.local.preferences.OpenDisplayMagicEarthUriAutomation
 import page.ooooo.geoshare.data.local.preferences.OpenNavigationGoogleUriAutomation
@@ -43,6 +44,7 @@ import page.ooooo.geoshare.lib.outputs.CopyCoordsDegMinSecOutput
 import page.ooooo.geoshare.lib.outputs.CopyGeoUriOutput
 import page.ooooo.geoshare.lib.outputs.CopyLinkUriOutput
 import page.ooooo.geoshare.lib.outputs.NoopOutput
+import page.ooooo.geoshare.lib.outputs.OpenDisplayCartesIGNUrlOutput
 import page.ooooo.geoshare.lib.outputs.OpenDisplayGeoUriOutput
 import page.ooooo.geoshare.lib.outputs.OpenDisplayMagicEarthUriOutput
 import page.ooooo.geoshare.lib.outputs.OpenNavigationGoogleUriOutput
@@ -106,6 +108,9 @@ class OutputRepository @Inject constructor(
             buildList {
                 if (DataType.GEO_URI in dataTypes) {
                     add(OpenDisplayGeoUriOutput(packageName, coordinateConverter))
+                }
+                if (DataType.CARTES_IGN_URL in dataTypes) {
+                    add(OpenDisplayCartesIGNUrlOutput(packageName, coordinateConverter))
                 }
                 if (DataType.MAGIC_EARTH_URI in dataTypes) {
                     add(OpenDisplayMagicEarthUriOutput(packageName, coordinateConverter))
@@ -224,6 +229,11 @@ class OutputRepository @Inject constructor(
             is OpenDisplayGeoUriAutomation ->
                 automation.packageName?.let { packageName ->
                     OpenDisplayGeoUriOutput(packageName, coordinateConverter)
+                }
+
+            is OpenDisplayCartesIGNUrlAutomation ->
+                automation.packageName?.let { packageName ->
+                    OpenDisplayCartesIGNUrlOutput(packageName, coordinateConverter)
                 }
 
             is OpenDisplayMagicEarthUriAutomation ->

--- a/app/src/main/java/page/ooooo/geoshare/data/local/preferences/Automation.kt
+++ b/app/src/main/java/page/ooooo/geoshare/data/local/preferences/Automation.kt
@@ -69,6 +69,10 @@ object NoopAutomation : Automation
 data class OpenDisplayGeoUriAutomation(val packageName: String?) : Automation
 
 @Serializable
+@SerialName("OPEN_DISPLAY_CARTES_IGN_URL")
+data class OpenDisplayCartesIGNUrlAutomation(val packageName: String?) : Automation
+
+@Serializable
 @SerialName("OPEN_DISPLAY_MAGIC_EARTH_URI")
 data class OpenDisplayMagicEarthUriAutomation(val packageName: String?) : Automation
 

--- a/app/src/main/java/page/ooooo/geoshare/lib/android/AndroidTools.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/android/AndroidTools.kt
@@ -159,6 +159,16 @@ object AndroidTools {
             }
             for (packageName in queryPackageNames(
                 packageManager,
+                Intent(Intent.ACTION_VIEW, "https://cartes-ign.ign.fr".toUri()),
+            )) {
+                getOrPut(packageName) { mutableSetOf() }.apply {
+                    add(DataType.CARTES_IGN_URL)
+                    // Remove support for geo: URIs from the Cartes IGN app, because it doesn't support these URIs well
+                    remove(DataType.GEO_URI)
+                }
+            }
+            for (packageName in queryPackageNames(
+                packageManager,
                 Intent(Intent.ACTION_VIEW, "magicearth:".toUri()),
             )) {
                 getOrPut(packageName) { mutableSetOf() }.apply {

--- a/app/src/main/java/page/ooooo/geoshare/lib/android/DataType.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/android/DataType.kt
@@ -1,6 +1,7 @@
 package page.ooooo.geoshare.lib.android
 
 enum class DataType {
+    CARTES_IGN_URL,
     GEO_URI,
     GOOGLE_NAVIGATION_URI,
     GOOGLE_STREET_VIEW_URI,

--- a/app/src/main/java/page/ooooo/geoshare/lib/android/PackageNames.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/android/PackageNames.kt
@@ -8,6 +8,7 @@ import page.ooooo.geoshare.lib.geo.Srs
 object PackageNames {
     const val AMAP = "com.autonavi.minimap"
     const val BAIDU_MAP = "com.baidu.BaiduMap"
+    const val CARTES_IGN = "fr.ign.geoportail"
     const val COMAPS_FDROID = "app.comaps.fdroid"
     const val COMAPS_PREFIX = "app.comaps."
     const val GARMIN_PREFIX = "com.garmin."

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/OpenDisplayCartesIGNUrlOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/OpenDisplayCartesIGNUrlOutput.kt
@@ -1,0 +1,56 @@
+package page.ooooo.geoshare.lib.outputs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import page.ooooo.geoshare.R
+import page.ooooo.geoshare.lib.UriQuote
+import page.ooooo.geoshare.lib.android.AppDetails
+import page.ooooo.geoshare.lib.formatters.UriFormatter
+import page.ooooo.geoshare.lib.geo.CoordinateConverter
+import page.ooooo.geoshare.lib.geo.Point
+import page.ooooo.geoshare.ui.components.DrawableIconDescriptor
+import page.ooooo.geoshare.ui.components.ResourceIconDescriptor
+import javax.inject.Inject
+
+/**
+ * This output creates a Cartes IGN URL and opens it in [packageName].
+ *
+ * We need this output, because Cartes IGN doesn't properly support geo: URIs.
+ */
+class OpenDisplayCartesIGNUrlOutput @Inject constructor(
+    override val packageName: String,
+    private val coordinateConverter: CoordinateConverter,
+) : OpenPointOutput {
+    override fun getText(value: Point, uriQuote: UriQuote) =
+        UriFormatter.formatUriString(
+            coordinateConverter.toWGS84(value),
+            "https://cartes-ign.ign.fr?lng={lon}&lat={lat}&z={z}",
+            uriQuote = uriQuote,
+        )
+
+    @Composable
+    override fun label(appDetails: AppDetails) =
+        stringResource(R.string.output_open_display)
+
+    override fun getMenuIcon(appDetails: AppDetails) =
+        ResourceIconDescriptor(R.drawable.location_on_24px)
+
+    override fun getIcon(appDetails: AppDetails) =
+        appDetails[packageName]?.let { DrawableIconDescriptor(it.icon) }
+
+    @Composable
+    override fun automationLabel(appDetails: AppDetails) =
+        stringResource(
+            R.string.conversion_succeeded_open_app_display,
+            appDetails[packageName]?.label ?: packageName,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as OpenDisplayCartesIGNUrlOutput
+        return packageName == other.packageName
+    }
+
+    override fun hashCode() = packageName.hashCode()
+}

--- a/app/src/test/java/page/ooooo/geoshare/data/OutputRepositoryTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/data/OutputRepositoryTest.kt
@@ -22,6 +22,7 @@ import page.ooooo.geoshare.data.local.preferences.CopyCoordsDegMinSecAutomation
 import page.ooooo.geoshare.data.local.preferences.CopyGeoUriAutomation
 import page.ooooo.geoshare.data.local.preferences.CopyLinkUriAutomation
 import page.ooooo.geoshare.data.local.preferences.NoopAutomation
+import page.ooooo.geoshare.data.local.preferences.OpenDisplayCartesIGNUrlAutomation
 import page.ooooo.geoshare.data.local.preferences.OpenDisplayGeoUriAutomation
 import page.ooooo.geoshare.data.local.preferences.OpenDisplayMagicEarthUriAutomation
 import page.ooooo.geoshare.data.local.preferences.OpenNavigationGoogleUriAutomation
@@ -48,6 +49,7 @@ import page.ooooo.geoshare.lib.outputs.CopyCoordsDegMinSecOutput
 import page.ooooo.geoshare.lib.outputs.CopyGeoUriOutput
 import page.ooooo.geoshare.lib.outputs.CopyLinkUriOutput
 import page.ooooo.geoshare.lib.outputs.NoopOutput
+import page.ooooo.geoshare.lib.outputs.OpenDisplayCartesIGNUrlOutput
 import page.ooooo.geoshare.lib.outputs.OpenDisplayGeoUriOutput
 import page.ooooo.geoshare.lib.outputs.OpenDisplayMagicEarthUriOutput
 import page.ooooo.geoshare.lib.outputs.OpenNavigationGoogleUriOutput
@@ -127,6 +129,9 @@ class OutputRepositoryTest {
                     OpenRouteGpxOutput(PackageNames.GOOGLE_MAPS, coordinateConverter),
                     OpenPointsGpxOutput(PackageNames.GOOGLE_MAPS, coordinateConverter),
                 ),
+                PackageNames.CARTES_IGN to listOf(
+                    OpenDisplayCartesIGNUrlOutput(PackageNames.CARTES_IGN, coordinateConverter),
+                ),
                 PackageNames.MAGIC_EARTH to listOf(
                     OpenDisplayMagicEarthUriOutput(PackageNames.MAGIC_EARTH, coordinateConverter),
                     OpenNavigationMagicEarthUriOutput(PackageNames.MAGIC_EARTH, coordinateConverter),
@@ -148,6 +153,7 @@ class OutputRepositoryTest {
                         DataType.GOOGLE_STREET_VIEW_URI,
                         DataType.GPX_DATA,
                     ),
+                    PackageNames.CARTES_IGN to setOf(DataType.CARTES_IGN_URL),
                     PackageNames.MAGIC_EARTH to setOf(DataType.MAGIC_EARTH_URI),
                     PackageNames.SIGNAL to setOf(DataType.SEND_PLAIN_TEXT),
                     PackageNames.TOMTOM to setOf(DataType.GPX_ONE_POINT_DATA),
@@ -325,6 +331,7 @@ class OutputRepositoryTest {
                     SavePointsGpxOutput(coordinateConverter),
                 ),
                 listOf(
+                    OpenDisplayCartesIGNUrlOutput(PackageNames.CARTES_IGN, coordinateConverter),
                     OpenDisplayMagicEarthUriOutput(PackageNames.MAGIC_EARTH, coordinateConverter),
                     OpenNavigationMagicEarthUriOutput(PackageNames.MAGIC_EARTH, coordinateConverter),
                     SendPointOutput(PackageNames.SIGNAL, coordinateConverter),
@@ -373,6 +380,7 @@ class OutputRepositoryTest {
                     SavePointsGpxAutomation,
                 ),
                 listOf(
+                    OpenDisplayCartesIGNUrlAutomation(PackageNames.CARTES_IGN),
                     OpenDisplayMagicEarthUriAutomation(PackageNames.MAGIC_EARTH),
                     OpenNavigationMagicEarthUriAutomation(PackageNames.MAGIC_EARTH),
                     SendPointAutomation(PackageNames.SIGNAL),

--- a/app/src/test/java/page/ooooo/geoshare/lib/outputs/OpenDisplayCartesIGNUrlOutputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/outputs/OpenDisplayCartesIGNUrlOutputTest.kt
@@ -1,0 +1,53 @@
+package page.ooooo.geoshare.lib.outputs
+
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import page.ooooo.geoshare.lib.FakeUriQuote
+import page.ooooo.geoshare.lib.android.PackageNames
+import page.ooooo.geoshare.lib.geo.CoordinateConverter
+import page.ooooo.geoshare.lib.geo.GCJ02Point
+import page.ooooo.geoshare.lib.geo.GeoTest
+import page.ooooo.geoshare.lib.geo.Source
+import page.ooooo.geoshare.lib.geo.WGS84Point
+
+class OpenDisplayCartesIGNUrlOutputTest : GeoTest {
+    private val geometries = mockGeometries()
+    private val coordinateConverter = CoordinateConverter(geometries)
+    private val uriQuote = FakeUriQuote
+
+    @Test
+    fun getText_whenPointIsWGS84AndWithinMainlandChina_returnsUrlWithConvertedCoordinates() {
+        assertEquals(
+            "https://cartes-ign.ign.fr?lng=121.4709921&lat=31.2304417&z=3.14",
+            OpenDisplayCartesIGNUrlOutput(PackageNames.TEST, coordinateConverter)
+                .getText(
+                    WGS84Point(31.23044166868017, 121.47099209401793, z = 3.14, source = Source.GENERATED),
+                    uriQuote,
+                ),
+        )
+    }
+
+    @Test
+    fun getText_whenPointIsGCJ02AndWithinMainlandChinaAndLinkSrsIsGCJ02MainlandChina_returnsUrlWithUnchangedCoordinates() {
+        assertEquals(
+            "https://cartes-ign.ign.fr?lng=121.4709921&lat=31.2304417&z=3.14",
+            OpenDisplayCartesIGNUrlOutput(PackageNames.TEST, coordinateConverter)
+                .getText(
+                    GCJ02Point(31.22850685422705, 121.47552456472106, z = 3.14, source = Source.GENERATED),
+                    uriQuote,
+                ),
+        )
+    }
+
+    @Test
+    fun getText_whenPointDoesNotHaveCoordinates_returnsNull() {
+        assertNull(
+            OpenDisplayCartesIGNUrlOutput(PackageNames.TEST, coordinateConverter)
+                .getText(
+                    GCJ02Point(name = "foo bar", source = Source.GENERATED),
+                    uriQuote,
+                )
+        )
+    }
+}

--- a/fastlane/metadata/android/en-US/changelogs/42.txt
+++ b/fastlane/metadata/android/en-US/changelogs/42.txt
@@ -1,2 +1,3 @@
 - Added the option to send a point via selected messaging apps.
 - Added the option to save a point to a contact.
+- Fixed pin display when opening Cartes IGN.


### PR DESCRIPTION
Share Cartes IGN URL instead of geo: URI with Cartes IGN, because its support for geo: URIs is bad.

Fixes: #441