### PR TITLE
Close GeoShare after opening a map app

### DIFF
--- a/app/src/androidTest/java/page/ooooo/geoshare/ConversionBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/ConversionBehaviorTest.kt
@@ -43,6 +43,14 @@ class ConversionBehaviorTest : BehaviorTest {
 
         // Google Maps shows precise location
         waitAndAssertGoogleMapsContainsElement { textAsString() in setOf("Westend", "Berlin-Westend") }
+
+        // Go back to app
+        launchApplication()
+        waitForAppToBeVisible()
+        closeIntro()
+
+        // Shows main screen instead of result screen, because the app finished
+        onElement { viewIdResourceName == "geoShareMainSourceTextField" }
     }
 
     @Test
@@ -441,7 +449,7 @@ class ConversionBehaviorTest : BehaviorTest {
         }
 
         // Share a Google Maps short link with the app
-        shareUri("https://maps.app.goo.gl/v4MDUi9mCrh3mNjz8") // Sometimes fails in emulator
+        shareUri("https://maps.app.goo.gl/v4MDUi9mCrh3mNjz8") // Fails in emulator API 36.1 but not API 35 for some reason
 
         // Grant connection permission
         onElement(20_000L) { viewIdResourceName == "geoShareConnectionPermissionDialog" }.confirmDialog()
@@ -534,7 +542,6 @@ class ConversionBehaviorTest : BehaviorTest {
     fun savesGpxRoute() = uiAutomator {
         // Launch application and close intro
         launchApplication()
-        waitForAppToBeVisible()
         waitForAppToBeVisible()
         closeIntro()
 

--- a/app/src/androidTest/java/page/ooooo/geoshare/ConversionBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/ConversionBehaviorTest.kt
@@ -475,7 +475,7 @@ class ConversionBehaviorTest : BehaviorTest {
             onElement { viewIdResourceName == "geoShareApp_${messagingAppPackageName}" }.click()
 
             // Opens the messaging app
-            onElement { this.packageName == messagingAppPackageName }
+            onElement { packageName == messagingAppPackageName }
         }
     }
 

--- a/app/src/androidTest/java/page/ooooo/geoshare/InputsBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/InputsBehaviorTest.kt
@@ -17,7 +17,6 @@ class InputsBehaviorTest : BehaviorTest {
         // Launch app
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
 
         // Go to the second intro page
         onElement { viewIdResourceName == "geoShareIntroPage0HeadingText" }
@@ -26,7 +25,6 @@ class InputsBehaviorTest : BehaviorTest {
         // Relaunch app
         closeApplication()
         launchApplication()
-        waitForAppToBeVisible()
         waitForAppToBeVisible()
 
         // Intro is still visible; go through all intro pages
@@ -42,7 +40,6 @@ class InputsBehaviorTest : BehaviorTest {
         closeApplication()
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
 
         // Main screen is visible again
         onElement { viewIdResourceName == "geoShareMainSourceTextField" }
@@ -52,7 +49,6 @@ class InputsBehaviorTest : BehaviorTest {
     fun whenOpenWithOldVersionCode_showsRecentInputsAndSavesNewVersionCode() = uiAutomator {
         // Launch application and close intro
         launchApplication()
-        waitForAppToBeVisible()
         waitForAppToBeVisible()
         closeIntro()
 

--- a/app/src/androidTest/java/page/ooooo/geoshare/IntroBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/IntroBehaviorTest.kt
@@ -13,7 +13,6 @@ class IntroBehaviorTest : BehaviorTest {
         // Launch app
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
 
         // Go to the second intro page
         onElement { viewIdResourceName == "geoShareIntroPage0HeadingText" }
@@ -22,7 +21,6 @@ class IntroBehaviorTest : BehaviorTest {
         // Relaunch app
         closeApplication()
         launchApplication()
-        waitForAppToBeVisible()
         waitForAppToBeVisible()
 
         // Intro is still visible; go through all intro pages
@@ -37,7 +35,6 @@ class IntroBehaviorTest : BehaviorTest {
         // Relaunch app
         closeApplication()
         launchApplication()
-        waitForAppToBeVisible()
         waitForAppToBeVisible()
 
         // Main screen is visible again

--- a/app/src/androidTest/java/page/ooooo/geoshare/MainBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/MainBehaviorTest.kt
@@ -1,0 +1,43 @@
+package page.ooooo.geoshare
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.uiAutomator
+import org.junit.Test
+import org.junit.runner.RunWith
+import page.ooooo.geoshare.inputs.InputBehaviorTest
+import page.ooooo.geoshare.lib.android.PackageNames
+import page.ooooo.geoshare.lib.geo.Source
+import page.ooooo.geoshare.lib.geo.WGS84Point
+
+@RunWith(AndroidJUnit4::class)
+class MainBehaviorTest : InputBehaviorTest {
+
+    @Test
+    fun whenTextIsEntered_showsPointAndAllowsOpeningGoogleMaps() = uiAutomator {
+        assumeAppInstalled(PackageNames.GOOGLE_MAPS)
+
+        // Launch app and close intro
+        launchApplication()
+        waitForAppToBeVisible()
+        closeIntro()
+
+        // Enter text in the main form and submit it
+        testText(
+            WGS84Point(45.4786785, 9.2473799, source = Source.URI),
+            "geo:45.4786785,9.2473799",
+        )
+
+        // Tap the Google Maps icon
+        onElement { viewIdResourceName == "geoShareApp_${PackageNames.GOOGLE_MAPS}" }.click()
+
+        // Wait for Google Maps
+        onElement(20_000L) { packageName == PackageNames.GOOGLE_MAPS }
+
+        // Go back to app
+        launchApplication()
+        waitForAppToBeVisible()
+
+        // Shows result screen, because the app didn't finish
+        onElement { viewIdResourceName == "geoShareResultAutomationButton" }
+    }
+}

--- a/app/src/androidTest/java/page/ooooo/geoshare/UserPreferencesBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/UserPreferencesBehaviorTest.kt
@@ -32,7 +32,6 @@ class UserPreferencesBehaviorTest : BehaviorTest {
         // Launch application and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Share a URI with the app
@@ -86,7 +85,6 @@ class UserPreferencesBehaviorTest : BehaviorTest {
         // Launch application and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Share a URI with the app
@@ -133,7 +131,6 @@ class UserPreferencesBehaviorTest : BehaviorTest {
 
         // Launch application and close intro
         launchApplication()
-        waitForAppToBeVisible()
         waitForAppToBeVisible()
         closeIntro()
 

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/AppleMapsInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/AppleMapsInputBehaviorTest.kt
@@ -12,7 +12,6 @@ class AppleMapsInputBehaviorTest : InputBehaviorTest {
         // Launch app and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Coordinates
@@ -55,7 +54,6 @@ class AppleMapsInputBehaviorTest : InputBehaviorTest {
 
         // Launch app and close intro
         launchApplication()
-        waitForAppToBeVisible()
         waitForAppToBeVisible()
         closeIntro()
         setUserPreferenceConnectionPermissionToAlways()

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/CoordinateInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/CoordinateInputBehaviorTest.kt
@@ -11,7 +11,6 @@ class CoordinateInputBehaviorTest : InputBehaviorTest {
         // Launch app and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Decimal

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/GeoUriInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/GeoUriInputBehaviorTest.kt
@@ -11,7 +11,6 @@ class GeoUriInputBehaviorTest : InputBehaviorTest {
         // Launch app and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Coordinates, query and zoom

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/GoogleMapsInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/GoogleMapsInputBehaviorTest.kt
@@ -117,7 +117,6 @@ class GoogleMapsInputBehaviorTest : InputBehaviorTest {
         // Launch app and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
         setUserPreferenceConnectionPermissionToAlways()
 

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/MapsMeInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/MapsMeInputBehaviorTest.kt
@@ -11,7 +11,6 @@ class MapsMeInputBehaviorTest : InputBehaviorTest {
         // Launch app and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Custom scheme

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/OpenStreetMapInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/OpenStreetMapInputBehaviorTest.kt
@@ -44,7 +44,6 @@ class OpenStreetMapInputBehaviorTest : InputBehaviorTest {
         // Launch app and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
         setUserPreferenceConnectionPermissionToAlways()
 

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/WazeInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/WazeInputBehaviorTest.kt
@@ -12,7 +12,6 @@ class WazeInputBehaviorTest : InputBehaviorTest {
         // Launch app and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Coordinates

--- a/app/src/androidTestDemo/java/page/ooooo/geoshare/DemoBillingBehaviorTest.kt
+++ b/app/src/androidTestDemo/java/page/ooooo/geoshare/DemoBillingBehaviorTest.kt
@@ -23,7 +23,6 @@ class DemoBillingBehaviorTest : BehaviorTest {
         // Launch application and close intro
         launchApplication()
         waitForAppToBeVisible()
-        waitForAppToBeVisible()
         closeIntro()
 
         // Shows free headline

--- a/app/src/androidTestFree/java/page/ooooo/geoshare/AutomationBehaviorTest.kt
+++ b/app/src/androidTestFree/java/page/ooooo/geoshare/AutomationBehaviorTest.kt
@@ -88,8 +88,9 @@ class AutomationBehaviorTest : BehaviorTest {
         launchApplication()
         waitForAppToBeVisible()
 
-        // Shows automation preferences button
-        onElement { viewIdResourceName == "geoShareResultAutomationButton" }
+        // Shows automation screen instead of result screen, because the app finished and the automation screen is the
+        // one we had last opened when we were configuring automation
+        onElement { viewIdResourceName == "geoShareUserPreferencesControlsPane" }
     }
 
     @Test

--- a/app/src/androidTestFree/java/page/ooooo/geoshare/AutomationBehaviorTest.kt
+++ b/app/src/androidTestFree/java/page/ooooo/geoshare/AutomationBehaviorTest.kt
@@ -120,7 +120,7 @@ class AutomationBehaviorTest : BehaviorTest {
             onElement { viewIdResourceName == "geoShareResultSuccessAutomationCounter" }
 
             // Opens the messaging app
-            onElement { this.packageName == messagingAppPackageName }
+            onElement { packageName == messagingAppPackageName }
         }
     }
 

--- a/app/src/main/java/page/ooooo/geoshare/ConversionActivity.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ConversionActivity.kt
@@ -27,7 +27,7 @@ class ConversionActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             AppTheme {
-                MainNavigation(billingViewModel, conversionViewModel, introEnabled = false)
+                MainNavigation(billingViewModel, conversionViewModel, introEnabled = false, onFinish = { finish() })
             }
         }
     }

--- a/app/src/main/java/page/ooooo/geoshare/lib/conversion/ConversionState.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/conversion/ConversionState.kt
@@ -517,31 +517,38 @@ data class ActionRan(
     val isAutomation: Boolean,
 ) : ConversionState, ConversionState.HasResult {
     override suspend fun transition(): State = action.output.let { output ->
-        when (actionResult) {
-            // TODO Test
-            ActionResult.Succeeded, ActionResult.SucceededAndFinish ->
-                when (output) {
-                    is Output.HasSuccessText if !isAutomation ->
+        if (!isAutomation) {
+            when (actionResult) {
+                ActionResult.Succeeded, ActionResult.SucceededAndFinish ->
+                    if (output is Output.HasSuccessText) {
                         ActionSucceeded(source, points, actionResult, output)
-
-                    is Output.HasAutomationSuccessText if isAutomation ->
-                        ActionAutomationSucceeded(source, points, actionResult, output)
-
-                    else ->
+                    } else {
                         ActionFinished(source, points, actionResult)
-                }
+                    }
 
-            ActionResult.Failed ->
-                when (output) {
-                    is Output.HasErrorText if !isAutomation ->
+                ActionResult.Failed ->
+                    if (output is Output.HasErrorText) {
                         ActionFailed(source, points, actionResult, output)
-
-                    is Output.HasAutomationErrorText if isAutomation ->
-                        ActionAutomationFailed(source, points, actionResult, output)
-
-                    else ->
+                    } else {
                         ActionFinished(source, points, actionResult)
-                }
+                    }
+            }
+        } else {
+            when (actionResult) {
+                ActionResult.Succeeded, ActionResult.SucceededAndFinish ->
+                    if (output is Output.HasAutomationSuccessText) {
+                        ActionAutomationSucceeded(source, points, actionResult, output)
+                    } else {
+                        ActionFinished(source, points, actionResult)
+                    }
+
+                ActionResult.Failed ->
+                    if (output is Output.HasAutomationErrorText) {
+                        ActionAutomationFailed(source, points, actionResult, output)
+                    } else {
+                        ActionFinished(source, points, actionResult)
+                    }
+            }
         }
     }
 }

--- a/app/src/main/java/page/ooooo/geoshare/lib/conversion/ConversionState.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/conversion/ConversionState.kt
@@ -34,6 +34,7 @@ import page.ooooo.geoshare.lib.network.NetworkTools
 import page.ooooo.geoshare.lib.network.RecoverableNetworkException
 import page.ooooo.geoshare.lib.network.UnrecoverableNetworkException
 import page.ooooo.geoshare.lib.outputs.Action
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import page.ooooo.geoshare.lib.outputs.BasicAction
 import page.ooooo.geoshare.lib.outputs.FileAction
 import page.ooooo.geoshare.lib.outputs.LocationAction
@@ -364,7 +365,7 @@ data class DataParsed<T>(
         }
 
     private companion object {
-        private const val TAG = "ConversionSucceeded"
+        private const val TAG = "DataParsed"
     }
 }
 
@@ -436,7 +437,7 @@ data class ConversionSucceeded(
             }
             if (output is Output.HasAutomationDelay) {
                 val delay = stateContext.userPreferencesRepository.getValue(AutomationDelayPreference)
-                return ActionWaiting(stateContext, source, points, action, isAutomation = true, delay = delay)
+                return ActionWaiting(stateContext, source, points, action, output, isAutomation = true, delay = delay)
             }
             return ActionReady(source, points, action, isAutomation = true)
         }
@@ -458,6 +459,7 @@ data class ActionWaiting(
     override val source: String,
     override val points: Points,
     val action: Action<*>,
+    val output: Output.HasAutomationDelay,
     @Suppress("SameParameterValue") val isAutomation: Boolean,
     val delay: Duration,
 ) : ConversionState, ConversionState.HasResult {
@@ -467,7 +469,7 @@ data class ActionWaiting(
         }
         ActionReady(source, points, action, isAutomation)
     } catch (_: CancellationException) {
-        ActionFinished(source, points, action, isAutomation)
+        ActionFinished(source, points, ActionResult.Failed)
     }
 }
 
@@ -511,21 +513,44 @@ data class ActionRan(
     override val source: String,
     override val points: Points,
     val action: Action<*>,
+    val actionResult: ActionResult,
     val isAutomation: Boolean,
-    val success: Boolean?,
 ) : ConversionState, ConversionState.HasResult {
-    override suspend fun transition(): State = when (success) {
-        true -> ActionSucceeded(source, points, action, isAutomation)
-        false -> ActionFailed(source, points, action, isAutomation)
-        else -> ActionFinished(source, points, action, isAutomation)
+    override suspend fun transition(): State = action.output.let { output ->
+        when (actionResult) {
+            // TODO Test
+            ActionResult.Succeeded, ActionResult.SucceededAndFinish ->
+                when (output) {
+                    is Output.HasSuccessText if !isAutomation ->
+                        ActionSucceeded(source, points, actionResult, output)
+
+                    is Output.HasAutomationSuccessText if isAutomation ->
+                        ActionAutomationSucceeded(source, points, actionResult, output)
+
+                    else ->
+                        ActionFinished(source, points, actionResult)
+                }
+
+            ActionResult.Failed ->
+                when (output) {
+                    is Output.HasErrorText if !isAutomation ->
+                        ActionFailed(source, points, actionResult, output)
+
+                    is Output.HasAutomationErrorText if isAutomation ->
+                        ActionAutomationFailed(source, points, actionResult, output)
+
+                    else ->
+                        ActionFinished(source, points, actionResult)
+                }
+        }
     }
 }
 
 data class ActionSucceeded(
     override val source: String,
     override val points: Points,
-    val action: Action<*>,
-    val isAutomation: Boolean,
+    val actionResult: ActionResult,
+    val output: Output.HasSuccessText,
 ) : ConversionState, ConversionState.HasResult {
     override suspend fun transition(): State {
         try {
@@ -533,15 +558,31 @@ data class ActionSucceeded(
         } catch (_: CancellationException) {
             // Do nothing
         }
-        return ActionFinished(source, points, action, isAutomation)
+        return ActionFinished(source, points, actionResult)
+    }
+}
+
+data class ActionAutomationSucceeded(
+    override val source: String,
+    override val points: Points,
+    val actionResult: ActionResult,
+    val output: Output.HasAutomationSuccessText,
+) : ConversionState, ConversionState.HasResult {
+    override suspend fun transition(): State {
+        try {
+            delay(3.seconds)
+        } catch (_: CancellationException) {
+            // Do nothing
+        }
+        return ActionFinished(source, points, actionResult)
     }
 }
 
 data class ActionFailed(
     override val source: String,
     override val points: Points,
-    val action: Action<*>,
-    val isAutomation: Boolean,
+    val actionResult: ActionResult,
+    val output: Output.HasErrorText,
 ) : ConversionState, ConversionState.HasResult {
     override suspend fun transition(): State {
         try {
@@ -549,15 +590,30 @@ data class ActionFailed(
         } catch (_: CancellationException) {
             // Do nothing
         }
-        return ActionFinished(source, points, action, isAutomation)
+        return ActionFinished(source, points, actionResult)
+    }
+}
+
+data class ActionAutomationFailed(
+    override val source: String,
+    override val points: Points,
+    val actionResult: ActionResult,
+    val output: Output.HasAutomationErrorText,
+) : ConversionState, ConversionState.HasResult {
+    override suspend fun transition(): State {
+        try {
+            delay(3.seconds)
+        } catch (_: CancellationException) {
+            // Do nothing
+        }
+        return ActionFinished(source, points, actionResult)
     }
 }
 
 data class ActionFinished(
     override val source: String,
     override val points: Points,
-    val action: Action<*>,
-    val isAutomation: Boolean,
+    val actionResult: ActionResult, // = ActionResult.Succeeded,
 ) : ConversionState, ConversionState.HasResult
 
 data class FileUriRequested(
@@ -587,7 +643,7 @@ data class LocationRationaleShown(
         LocationRationaleConfirmed(source, points, action, isAutomation)
 
     override suspend fun deny(doNotAsk: Boolean): State =
-        ActionFinished(source, points, action, isAutomation)
+        ActionFinished(source, points, ActionResult.Failed)
 }
 
 data class LocationRationaleConfirmed(
@@ -617,17 +673,16 @@ data class LocationReceived(
     val location: Point?,
 ) : ConversionState, ConversionState.HasResult {
     override suspend fun transition(): State = if (location == null) {
-        LocationFindingFailed(source, points, action, isAutomation)
+        LocationFindingFailed(source, points, ActionResult.Failed)
     } else {
-        LocationActionReady(source, points, action, isAutomation = isAutomation, location = location)
+        LocationActionReady(source, points, action, isAutomation, location)
     }
 }
 
 data class LocationFindingFailed(
     override val source: String,
     override val points: Points,
-    val action: LocationAction<*>,
-    val isAutomation: Boolean,
+    val actionResult: ActionResult,
 ) : ConversionState, ConversionState.HasResult {
     override suspend fun transition(): State {
         try {
@@ -635,6 +690,6 @@ data class LocationFindingFailed(
         } catch (_: CancellationException) {
             // Do nothing
         }
-        return ActionFinished(source, points, action, isAutomation)
+        return ActionFinished(source, points, actionResult)
     }
 }

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/Action.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/Action.kt
@@ -29,7 +29,7 @@ sealed interface Action<T> {
  * Basic action is an [Action] that doesn't require anything other than a [value] ([Point] or [Points]) to be executed.
  */
 sealed interface BasicAction<T> : Action<T> {
-    suspend fun execute(actionContext: ActionContext): Boolean
+    suspend fun execute(actionContext: ActionContext): ActionResult
 
     data class WithPoint(
         override val value: Point,
@@ -63,7 +63,7 @@ sealed interface FileAction<T> : Action<T> {
 
     val mimeType: String
 
-    suspend fun execute(uri: Uri, actionContext: ActionContext): Boolean
+    suspend fun execute(uri: Uri, actionContext: ActionContext): ActionResult
 
     data class WithPoint(
         override val value: Point,
@@ -101,7 +101,7 @@ sealed interface FileAction<T> : Action<T> {
  * be executed.
  */
 sealed interface LocationAction<T> : Action<T> {
-    suspend fun execute(location: Point, actionContext: ActionContext): Boolean
+    suspend fun execute(location: Point, actionContext: ActionContext): ActionResult
 
     data class WithPoint(
         override val value: Point,

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/ActionResult.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/ActionResult.kt
@@ -1,0 +1,7 @@
+package page.ooooo.geoshare.lib.outputs
+
+enum class ActionResult {
+    Succeeded,
+    SucceededAndFinish,
+    Failed,
+}

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/NoopOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/NoopOutput.kt
@@ -7,7 +7,7 @@ import page.ooooo.geoshare.lib.android.AppDetails
 import page.ooooo.geoshare.lib.geo.Point
 
 class NoopOutput : PointOutput.WithoutLocation {
-    override suspend fun execute(value: Point, actionContext: ActionContext) = true
+    override suspend fun execute(value: Point, actionContext: ActionContext) = ActionResult.Succeeded
 
     @Composable
     override fun label(appDetails: AppDetails) =

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/OpenRouteOnePointGpxOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/OpenRouteOnePointGpxOutput.kt
@@ -35,13 +35,13 @@ class OpenRouteOnePointGpxOutput @Inject constructor(
         actionContext: ActionContext,
     ) =
         location?.let { location ->
-            // Notice that we use the .xml extension, because that's what TomTom requires.
+            // Don't use a .gpx extension but use .xml instead, because that's what TomTom requires
             writeFile(actionContext.context.filesDir, "routes", "${System.currentTimeMillis()}.xml") {
                 GpxFormatter.writeGpxRoute(coordinateConverter.toWGS84(persistentListOf(location, value)), this)
             }?.let { file ->
                 actionContext.androidTools.openAppFile(actionContext.context, packageName, file)
             }
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.SucceededAndFinish else ActionResult.Failed }
 
     @Composable
     override fun label(appDetails: AppDetails) =

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/Output.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/Output.kt
@@ -60,7 +60,7 @@ sealed interface PointOutput : Output {
      * Example: Copy point coordinates, Open point in an app
      */
     sealed interface WithoutLocation : PointOutput {
-        suspend fun execute(value: Point, actionContext: ActionContext): Boolean
+        suspend fun execute(value: Point, actionContext: ActionContext): ActionResult
 
         override fun toAction(value: Point) = BasicAction.WithPoint(value, this)
     }
@@ -76,7 +76,7 @@ sealed interface PointOutput : Output {
         val mimeType: String
 
         @Suppress("SameReturnValue")
-        suspend fun execute(uri: Uri, value: Point, actionContext: ActionContext): Boolean
+        suspend fun execute(uri: Uri, value: Point, actionContext: ActionContext): ActionResult
 
         override fun toAction(value: Point) = FileAction.WithPoint(value, this)
     }
@@ -87,7 +87,7 @@ sealed interface PointOutput : Output {
      * Example: Share a route from current location to a point
      */
     sealed interface WithLocation : PointOutput {
-        suspend fun execute(location: Point?, value: Point, actionContext: ActionContext): Boolean
+        suspend fun execute(location: Point?, value: Point, actionContext: ActionContext): ActionResult
 
         override fun toAction(value: Point) = LocationAction.WithPoint(value, this)
 
@@ -108,7 +108,7 @@ sealed interface PointsOutput : Output {
      * Example: Open GPX route in an app
      */
     sealed interface WithoutLocation : PointsOutput {
-        suspend fun execute(value: Points, actionContext: ActionContext): Boolean
+        suspend fun execute(value: Points, actionContext: ActionContext): ActionResult
 
         override fun toAction(value: Points) = BasicAction.WithPoints(value, this)
     }
@@ -124,7 +124,7 @@ sealed interface PointsOutput : Output {
         val mimeType: String
 
         @Suppress("SameReturnValue")
-        suspend fun execute(uri: Uri, value: Points, actionContext: ActionContext): Boolean
+        suspend fun execute(uri: Uri, value: Points, actionContext: ActionContext): ActionResult
 
         override fun toAction(value: Points) = FileAction.WithPoints(value, this)
     }
@@ -135,7 +135,7 @@ sealed interface PointsOutput : Output {
      * Example: Share route from current location to last point
      */
     sealed interface WithLocation : PointsOutput {
-        suspend fun execute(location: Point?, value: Points, actionContext: ActionContext): Boolean
+        suspend fun execute(location: Point?, value: Points, actionContext: ActionContext): ActionResult
 
         override fun toAction(value: Points) = LocationAction.WithPoints(value, this)
 

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/OutputImpl.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/OutputImpl.kt
@@ -25,7 +25,7 @@ sealed interface CopyPointOutput :
         getText(value, actionContext.uriQuote)?.let { text ->
             actionContext.androidTools.copyToClipboard(actionContext.clipboard, text)
             true
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.Succeeded else ActionResult.Failed }
 
     override fun getDescription(value: Point, uriQuote: UriQuote) =
         getText(value, uriQuote)
@@ -49,10 +49,10 @@ sealed interface OpenPointOutput :
 
     fun getText(value: Point, uriQuote: UriQuote = DefaultUriQuote): String? = null
 
-    override suspend fun execute(value: Point, actionContext: ActionContext): Boolean =
+    override suspend fun execute(value: Point, actionContext: ActionContext) =
         getText(value, actionContext.uriQuote)?.let { uriString ->
             actionContext.androidTools.openApp(actionContext.context, packageName, uriString)
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.SucceededAndFinish else ActionResult.Failed }
 
     override fun getIcon(appDetails: AppDetails) =
         appDetails[packageName]?.let { DrawableIconDescriptor(it.icon) }
@@ -104,7 +104,7 @@ sealed interface OpenPointsOutput :
             writePoints(value, this)
         }?.let { file ->
             actionContext.androidTools.openAppFile(actionContext.context, packageName, file)
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.SucceededAndFinish else ActionResult.Failed }
 
     override fun getIcon(appDetails: AppDetails) =
         appDetails[packageName]?.let { DrawableIconDescriptor(it.icon) }
@@ -184,10 +184,10 @@ sealed interface SharePointOutput :
 
     fun getText(value: Point, uriQuote: UriQuote = DefaultUriQuote): String? = null
 
-    override suspend fun execute(value: Point, actionContext: ActionContext): Boolean =
+    override suspend fun execute(value: Point, actionContext: ActionContext) =
         getText(value, actionContext.uriQuote)?.let { uriString ->
             actionContext.androidTools.openChooser(actionContext.context, uriString)
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.SucceededAndFinish else ActionResult.Failed }
 
     @Composable
     override fun errorText(appDetails: AppDetails) =
@@ -216,13 +216,11 @@ sealed interface SharePointsOutput :
     fun writePoints(value: Points, writer: Appendable)
 
     override suspend fun execute(value: Points, actionContext: ActionContext) =
-        writeFile(
-            actionContext.context.filesDir, "points", "${System.currentTimeMillis()}.gpx"
-        ) {
+        writeFile(actionContext.context.filesDir, "points", "${System.currentTimeMillis()}.gpx") {
             writePoints(value, this)
         }?.let { file ->
             actionContext.androidTools.openChooserFile(actionContext.context, file)
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.SucceededAndFinish else ActionResult.Failed }
 
     override fun getMenuIcon(appDetails: AppDetails) =
         ResourceIconDescriptor(R.drawable.route_24px)

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/SavePointGpxOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/SavePointGpxOutput.kt
@@ -31,7 +31,7 @@ class SavePointGpxOutput @Inject constructor(
     override suspend fun execute(uri: Uri, value: Point, actionContext: ActionContext) = withContext(Dispatchers.IO) {
         AndroidTools.openFileUri(actionContext.context, uri) {
             GpxFormatter.writeGpxPoints(coordinateConverter.toWGS84(persistentListOf(value)), this)
-        }
+        }.let { success -> if (success) ActionResult.Succeeded else ActionResult.Failed }
     }
 
     @Composable

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/SavePointToContactOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/SavePointToContactOutput.kt
@@ -29,7 +29,7 @@ class SavePointToContactOutput @Inject constructor(
             CoordinateFormatter.formatDecCoords(
                 coordinateConverter.toWGS84(value)
             ),
-        )
+        ).let { success -> if (success) ActionResult.Succeeded else ActionResult.Failed }
 
     @Composable
     override fun label(appDetails: AppDetails) =

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/SavePointsGpxOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/SavePointsGpxOutput.kt
@@ -30,7 +30,7 @@ class SavePointsGpxOutput @Inject constructor(
     override suspend fun execute(uri: Uri, value: Points, actionContext: ActionContext) = withContext(Dispatchers.IO) {
         AndroidTools.openFileUri(actionContext.context, uri) {
             GpxFormatter.writeGpxPoints(coordinateConverter.toWGS84(value), this)
-        }
+        }.let { success -> if (success) ActionResult.Succeeded else ActionResult.Failed }
     }
 
     @Composable

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/SaveRouteGpxOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/SaveRouteGpxOutput.kt
@@ -30,7 +30,7 @@ class SaveRouteGpxOutput @Inject constructor(
     override suspend fun execute(uri: Uri, value: Points, actionContext: ActionContext) = withContext(Dispatchers.IO) {
         AndroidTools.openFileUri(actionContext.context, uri) {
             GpxFormatter.writeGpxRoute(coordinateConverter.toWGS84(value), this)
-        }
+        }.let { success -> if (success) ActionResult.Succeeded else ActionResult.Failed }
     }
 
     @Composable

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/SendPointOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/SendPointOutput.kt
@@ -32,10 +32,10 @@ class SendPointOutput @Inject constructor(
             uriQuote = uriQuote,
         )
 
-    override suspend fun execute(value: Point, actionContext: ActionContext): Boolean =
+    override suspend fun execute(value: Point, actionContext: ActionContext) =
         getText(value, actionContext.uriQuote)?.let { text ->
             actionContext.androidTools.sendViaApp(actionContext.context, packageName, text)
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.SucceededAndFinish else ActionResult.Failed }
 
     @Composable
     override fun label(appDetails: AppDetails) =

--- a/app/src/main/java/page/ooooo/geoshare/lib/outputs/ShareLinkUriOutput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/outputs/ShareLinkUriOutput.kt
@@ -27,7 +27,7 @@ class ShareLinkUriOutput @Inject constructor(
     override suspend fun execute(value: Point, actionContext: ActionContext) =
         getText(value, actionContext.uriQuote)?.let { uriString ->
             AndroidTools.openWebUri(actionContext.context, uriString)
-        } ?: false
+        }.let { success -> if (success == true) ActionResult.SucceededAndFinish else ActionResult.Failed }
 
     @Composable
     override fun label(appDetails: AppDetails) =

--- a/app/src/main/java/page/ooooo/geoshare/ui/ConversionViewModel.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/ConversionViewModel.kt
@@ -45,6 +45,7 @@ import page.ooooo.geoshare.lib.conversion.State
 import page.ooooo.geoshare.lib.outputs.Action
 import page.ooooo.geoshare.lib.outputs.LocationAction
 import page.ooooo.geoshare.lib.geo.Point
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import javax.inject.Inject
 
 @OptIn(SavedStateHandleSaveableApi::class)
@@ -105,14 +106,14 @@ class ConversionViewModel @Inject constructor(
     }
 
     fun grant(doNotAsk: Boolean) {
-        (stateContext.currentState as? ConversionState.HasPermission)?.let { currentState ->
-            transition { currentState.grant(doNotAsk) }
+        (stateContext.currentState as? ConversionState.HasPermission)?.run {
+            transition { grant(doNotAsk) }
         }
     }
 
     fun deny(doNotAsk: Boolean) {
-        (stateContext.currentState as? ConversionState.HasPermission)?.let { currentState ->
-            transition { currentState.deny(doNotAsk) }
+        (stateContext.currentState as? ConversionState.HasPermission)?.run {
+            transition { deny(doNotAsk) }
         }
     }
 
@@ -129,152 +130,72 @@ class ConversionViewModel @Inject constructor(
     // Any action
 
     fun startAction(action: Action<*>) {
-        (stateContext.currentState as? ConversionState.HasResult)?.let { currentState ->
-            transition {
-                ActionReady(
-                    currentState.source,
-                    currentState.points,
-                    action,
-                    isAutomation = false
-                )
-            }
+        (stateContext.currentState as? ConversionState.HasResult)?.run {
+            transition { ActionReady(source, points, action, isAutomation = false) }
         }
     }
 
-    fun finishBasicAction(success: Boolean?) {
-        (stateContext.currentState as? BasicActionReady)?.let { currentState ->
-            transition {
-                ActionRan(
-                    currentState.source,
-                    currentState.points,
-                    currentState.action,
-                    currentState.isAutomation,
-                    success,
-                )
-            }
+    fun finishBasicAction(actionResult: ActionResult) {
+        (stateContext.currentState as? BasicActionReady)?.run {
+            transition { ActionRan(source, points, action, actionResult, isAutomation) }
         }
     }
 
     // File action
 
     fun receiveFileUri(uri: Uri) {
-        (stateContext.currentState as? FileUriRequested)?.let { currentState ->
-            transition {
-                FileActionReady(
-                    currentState.source,
-                    currentState.points,
-                    currentState.action,
-                    currentState.isAutomation,
-                    uri,
-                )
-            }
+        (stateContext.currentState as? FileUriRequested)?.run {
+            transition { FileActionReady(source, points, action, isAutomation, uri) }
         }
     }
 
     fun cancelFileUriRequest() {
-        (stateContext.currentState as? FileUriRequested)?.let { currentState ->
-            transition {
-                ActionFinished(
-                    currentState.source,
-                    currentState.points,
-                    currentState.action,
-                    currentState.isAutomation
-                )
-            }
+        (stateContext.currentState as? FileUriRequested)?.run {
+            transition { ActionFinished(source, points, ActionResult.Failed) }
         }
     }
 
-    fun finishFileAction(success: Boolean?) {
-        (stateContext.currentState as? FileActionReady)?.let { currentState ->
-            transition {
-                ActionRan(
-                    currentState.source,
-                    currentState.points,
-                    currentState.action,
-                    currentState.isAutomation,
-                    success,
-                )
-            }
+    fun finishFileAction(actionResult: ActionResult) {
+        (stateContext.currentState as? FileActionReady)?.run {
+            transition { ActionRan(source, points, action, actionResult, isAutomation) }
         }
     }
 
     // Location action
 
     fun showLocationRationale(action: LocationAction<*>, isAutomation: Boolean) {
-        (stateContext.currentState as? ConversionState.HasResult)?.let { currentState ->
-            transition {
-                LocationRationaleShown(
-                    currentState.source,
-                    currentState.points,
-                    action,
-                    isAutomation
-                )
-            }
+        (stateContext.currentState as? ConversionState.HasResult)?.run {
+            transition { LocationRationaleShown(source, points, action, isAutomation) }
         }
     }
 
     fun skipLocationRationale(action: LocationAction<*>, isAutomation: Boolean) {
-        (stateContext.currentState as? ConversionState.HasResult)?.let { currentState ->
-            transition {
-                LocationPermissionReceived(
-                    stateContext,
-                    currentState.source,
-                    currentState.points,
-                    action,
-                    isAutomation,
-                )
-            }
+        (stateContext.currentState as? ConversionState.HasResult)?.run {
+            transition { LocationPermissionReceived(stateContext, source, points, action, isAutomation) }
         }
     }
 
     fun receiveLocationPermission() {
-        (stateContext.currentState as? LocationRationaleConfirmed)?.let { currentState ->
-            transition {
-                LocationPermissionReceived(
-                    stateContext,
-                    currentState.source,
-                    currentState.points,
-                    currentState.action,
-                    currentState.isAutomation,
-                )
-            }
+        (stateContext.currentState as? LocationRationaleConfirmed)?.run {
+            transition { LocationPermissionReceived(stateContext, source, points, action, isAutomation) }
         }
     }
 
     fun receiveLocation(action: LocationAction<*>, isAutomation: Boolean, location: Point?) {
-        (stateContext.currentState as? ConversionState.HasResult)?.let { currentState ->
-            transition {
-                LocationReceived(
-                    currentState.source, currentState.points, action, isAutomation, location
-                )
-            }
+        (stateContext.currentState as? ConversionState.HasResult)?.run {
+            transition { LocationReceived(source, points, action, isAutomation, location) }
         }
     }
 
     fun cancelLocationFinding() {
-        (stateContext.currentState as? LocationPermissionReceived)?.let { currentState ->
-            transition {
-                ActionFinished(
-                    currentState.source,
-                    currentState.points,
-                    currentState.action,
-                    currentState.isAutomation
-                )
-            }
+        (stateContext.currentState as? LocationPermissionReceived)?.run {
+            transition { ActionFinished(source, points, ActionResult.Failed) }
         }
     }
 
-    fun finishLocationAction(success: Boolean?) {
-        (stateContext.currentState as? LocationActionReady)?.let { currentState ->
-            transition {
-                ActionRan(
-                    currentState.source,
-                    currentState.points,
-                    currentState.action,
-                    currentState.isAutomation,
-                    success,
-                )
-            }
+    fun finishLocationAction(actionResult: ActionResult) {
+        (stateContext.currentState as? LocationActionReady)?.run {
+            transition { ActionRan(source, points, action, actionResult, isAutomation) }
         }
     }
 

--- a/app/src/main/java/page/ooooo/geoshare/ui/MainNavigation.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/MainNavigation.kt
@@ -46,6 +46,7 @@ fun MainNavigation(
     billingViewModel: BillingViewModel,
     conversionViewModel: ConversionViewModel = hiltViewModel(),
     introEnabled: Boolean = true,
+    onFinish: () -> Unit = {},
     introViewModel: IntroViewModel = hiltViewModel(),
 ) {
     val navController = rememberNavController()
@@ -83,6 +84,7 @@ fun MainNavigation(
         }
         composable<MainRoute> {
             MainScreen(
+                onFinish = onFinish,
                 onNavigateToAboutScreen = { navController.navigate(AboutRoute) },
                 onNavigateToBillingScreen = { navController.navigate(BillingRoute) },
                 onNavigateToFaqScreen = { navController.navigate(FaqRoute) },

--- a/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
@@ -104,8 +104,6 @@ import page.ooooo.geoshare.lib.conversion.ConversionStateContext
 import page.ooooo.geoshare.lib.conversion.ConversionSucceeded
 import page.ooooo.geoshare.lib.conversion.FileActionReady
 import page.ooooo.geoshare.lib.conversion.FileUriRequested
-import page.ooooo.geoshare.lib.conversion.PermissionGrantedBasicInput
-import page.ooooo.geoshare.lib.conversion.PermissionGrantedWebViewInput
 import page.ooooo.geoshare.lib.conversion.Initial
 import page.ooooo.geoshare.lib.conversion.LoadingIndicator
 import page.ooooo.geoshare.lib.conversion.LocationActionReady
@@ -113,6 +111,8 @@ import page.ooooo.geoshare.lib.conversion.LocationPermissionReceived
 import page.ooooo.geoshare.lib.conversion.LocationRationaleConfirmed
 import page.ooooo.geoshare.lib.conversion.LocationRationaleRequested
 import page.ooooo.geoshare.lib.conversion.LocationRationaleShown
+import page.ooooo.geoshare.lib.conversion.PermissionGrantedBasicInput
+import page.ooooo.geoshare.lib.conversion.PermissionGrantedWebViewInput
 import page.ooooo.geoshare.lib.conversion.PermissionRequested
 import page.ooooo.geoshare.lib.conversion.State
 import page.ooooo.geoshare.lib.extensions.truncateMiddle
@@ -128,8 +128,8 @@ import page.ooooo.geoshare.lib.network.ConnectTimeoutNetworkException
 import page.ooooo.geoshare.lib.network.NetworkTools
 import page.ooooo.geoshare.lib.outputs.Action
 import page.ooooo.geoshare.lib.outputs.ActionContext
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import page.ooooo.geoshare.lib.outputs.LocationAction
-import page.ooooo.geoshare.lib.outputs.NoopAction
 import page.ooooo.geoshare.lib.outputs.OpenDisplayGeoUriOutput
 import page.ooooo.geoshare.lib.outputs.Output
 import page.ooooo.geoshare.lib.outputs.PointOutput
@@ -157,6 +157,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun MainScreen(
+    onFinish: () -> Unit,
     onNavigateToAboutScreen: () -> Unit,
     onNavigateToBillingScreen: () -> Unit,
     onNavigateToFaqScreen: () -> Unit,
@@ -212,6 +213,12 @@ fun MainScreen(
     LaunchedEffect(currentState) {
         currentState.let { currentState ->
             when (currentState) {
+                // All actions
+
+                is ActionFinished if currentState.actionResult == ActionResult.SucceededAndFinish -> {
+                    onFinish()
+                }
+
                 // Basic action
 
                 is BasicActionReady -> {
@@ -220,8 +227,8 @@ fun MainScreen(
                         clipboard = clipboard,
                         resources = resources,
                     )
-                    val success = currentState.action.execute(actionContext)
-                    conversionViewModel.finishBasicAction(success)
+                    val actionResult = currentState.action.execute(actionContext)
+                    conversionViewModel.finishBasicAction(actionResult)
                 }
 
                 // File action
@@ -246,8 +253,8 @@ fun MainScreen(
                         clipboard = clipboard,
                         resources = resources,
                     )
-                    val success = currentState.action.execute(currentState.uri, actionContext)
-                    conversionViewModel.finishFileAction(success)
+                    val actionResult = currentState.action.execute(currentState.uri, actionContext)
+                    conversionViewModel.finishFileAction(actionResult)
                 }
 
                 // Location action
@@ -285,8 +292,8 @@ fun MainScreen(
                         clipboard = clipboard,
                         resources = resources,
                     )
-                    val success = currentState.action.execute(currentState.location, actionContext)
-                    conversionViewModel.finishLocationAction(success)
+                    val actionResult = currentState.action.execute(currentState.location, actionContext)
+                    conversionViewModel.finishLocationAction(actionResult)
                 }
             }
         }
@@ -1124,8 +1131,7 @@ private fun SucceededPreview() {
                     WGS84Point(NaivePoint.genRandomPoint()),
                     WGS84Point(NaivePoint.example),
                 ),
-                action = NoopAction,
-                isAutomation = false,
+                actionResult = ActionResult.Succeeded,
             ),
             allInputs = emptyList(),
             appDetails = emptyMap(),
@@ -1203,8 +1209,7 @@ private fun DarkSucceededPreview() {
                     WGS84Point(NaivePoint.genRandomPoint()),
                     WGS84Point(NaivePoint.example),
                 ),
-                action = NoopAction,
-                isAutomation = false,
+                actionResult = ActionResult.Succeeded,
             ),
             allInputs = emptyList(),
             appDetails = emptyMap(),
@@ -1282,8 +1287,7 @@ private fun SmallSucceededPreview() {
                     WGS84Point(NaivePoint.genRandomPoint()),
                     WGS84Point(NaivePoint.example),
                 ),
-                action = NoopAction,
-                isAutomation = false,
+                actionResult = ActionResult.Succeeded,
             ),
             allInputs = emptyList(),
             appDetails = emptyMap(),
@@ -1361,8 +1365,7 @@ private fun TabletSucceededPreview() {
                     WGS84Point(NaivePoint.genRandomPoint()),
                     WGS84Point(NaivePoint.example),
                 ),
-                action = NoopAction,
-                isAutomation = false,
+                actionResult = ActionResult.Succeeded,
             ),
             allInputs = emptyList(),
             appDetails = emptyMap(),
@@ -1440,8 +1443,7 @@ private fun DarkTabletSucceededPreview() {
                     WGS84Point(NaivePoint.genRandomPoint()),
                     WGS84Point(NaivePoint.example),
                 ),
-                action = NoopAction,
-                isAutomation = false,
+                actionResult = ActionResult.Succeeded,
             ),
             allInputs = emptyList(),
             appDetails = emptyMap(),
@@ -1505,6 +1507,7 @@ private fun AutomationPreview() {
         val outputRepository = OutputRepository(
             coordinateConverter = coordinateConverter,
         )
+        val output = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
         MainScreen(
             currentState = ActionWaiting(
                 stateContext = ConversionStateContext(
@@ -1516,8 +1519,8 @@ private fun AutomationPreview() {
                 ),
                 source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                 points = persistentListOf(WGS84Point(NaivePoint.example)),
-                action = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
-                    .toAction(WGS84Point(source = Source.GENERATED)),
+                action = output.toAction(WGS84Point(source = Source.GENERATED)),
+                output = output,
                 isAutomation = true,
                 delay = 3.seconds,
             ),
@@ -1583,6 +1586,7 @@ private fun DarkAutomationPreview() {
         val outputRepository = OutputRepository(
             coordinateConverter = coordinateConverter,
         )
+        val output = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
         MainScreen(
             currentState = ActionWaiting(
                 stateContext = ConversionStateContext(
@@ -1594,8 +1598,8 @@ private fun DarkAutomationPreview() {
                 ),
                 source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                 points = persistentListOf(WGS84Point(NaivePoint.example)),
-                action = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
-                    .toAction(WGS84Point(source = Source.GENERATED)),
+                action = output.toAction(WGS84Point(source = Source.GENERATED)),
+                output = output,
                 isAutomation = true,
                 delay = 3.seconds,
             ),
@@ -1661,6 +1665,7 @@ private fun TabletAutomationPreview() {
         val outputRepository = OutputRepository(
             coordinateConverter = coordinateConverter,
         )
+        val output = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
         MainScreen(
             currentState = ActionWaiting(
                 stateContext = ConversionStateContext(
@@ -1672,8 +1677,8 @@ private fun TabletAutomationPreview() {
                 ),
                 source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                 points = persistentListOf(WGS84Point(NaivePoint.example)),
-                action = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
-                    .toAction(WGS84Point(source = Source.GENERATED)),
+                action = output.toAction(WGS84Point(source = Source.GENERATED)),
+                output = output,
                 isAutomation = true,
                 delay = 3.seconds,
             ),

--- a/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
@@ -213,12 +213,6 @@ fun MainScreen(
     LaunchedEffect(currentState) {
         currentState.let { currentState ->
             when (currentState) {
-                // All actions
-
-                is ActionFinished if currentState.actionResult == ActionResult.SucceededAndFinish -> {
-                    onFinish()
-                }
-
                 // Basic action
 
                 is BasicActionReady -> {
@@ -228,6 +222,9 @@ fun MainScreen(
                         resources = resources,
                     )
                     val actionResult = currentState.action.execute(actionContext)
+                    if (actionResult == ActionResult.SucceededAndFinish) {
+                        onFinish()
+                    }
                     conversionViewModel.finishBasicAction(actionResult)
                 }
 
@@ -254,6 +251,9 @@ fun MainScreen(
                         resources = resources,
                     )
                     val actionResult = currentState.action.execute(currentState.uri, actionContext)
+                    if (actionResult == ActionResult.SucceededAndFinish) {
+                        onFinish()
+                    }
                     conversionViewModel.finishFileAction(actionResult)
                 }
 
@@ -293,6 +293,9 @@ fun MainScreen(
                         resources = resources,
                     )
                     val actionResult = currentState.action.execute(currentState.location, actionContext)
+                    if (actionResult == ActionResult.SucceededAndFinish) {
+                        onFinish()
+                    }
                     conversionViewModel.finishLocationAction(actionResult)
                 }
             }

--- a/app/src/main/java/page/ooooo/geoshare/ui/components/ResultSuccessMessage.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/components/ResultSuccessMessage.kt
@@ -53,6 +53,8 @@ import page.ooooo.geoshare.lib.billing.BillingProduct
 import page.ooooo.geoshare.lib.billing.BillingStatus
 import page.ooooo.geoshare.lib.billing.CustomLinkFeature
 import page.ooooo.geoshare.lib.billing.Feature
+import page.ooooo.geoshare.lib.conversion.ActionAutomationFailed
+import page.ooooo.geoshare.lib.conversion.ActionAutomationSucceeded
 import page.ooooo.geoshare.lib.conversion.ActionFailed
 import page.ooooo.geoshare.lib.conversion.ActionFinished
 import page.ooooo.geoshare.lib.conversion.ActionSucceeded
@@ -65,10 +67,10 @@ import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Geometries
 import page.ooooo.geoshare.lib.geo.NaivePoint
 import page.ooooo.geoshare.lib.geo.WGS84Point
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import page.ooooo.geoshare.lib.outputs.OpenDisplayGeoUriOutput
 import page.ooooo.geoshare.lib.outputs.OpenRouteOnePointGpxOutput
-import page.ooooo.geoshare.lib.outputs.Output
-import page.ooooo.geoshare.lib.outputs.SharePointsGpxOutput
+import page.ooooo.geoshare.lib.outputs.SavePointsGpxOutput
 import page.ooooo.geoshare.ui.theme.AppTheme
 import page.ooooo.geoshare.ui.theme.LocalSpacing
 import kotlin.time.Duration.Companion.seconds
@@ -91,11 +93,11 @@ fun ResultSuccessMessage(
     AnimatedMessage(
         state = currentState,
         isMessageShown = { state ->
-            state is ActionWaiting && state.action.output is Output.HasAutomationDelay ||
-                state is ActionSucceeded && !state.isAutomation && state.action.output is Output.HasSuccessText ||
-                state is ActionFailed && !state.isAutomation && state.action.output is Output.HasErrorText ||
-                state is ActionSucceeded && state.isAutomation && state.action.output is Output.HasAutomationSuccessText ||
-                state is ActionFailed && state.isAutomation && state.action.output is Output.HasAutomationErrorText ||
+            state is ActionWaiting ||
+                state is ActionSucceeded ||
+                state is ActionAutomationSucceeded ||
+                state is ActionFailed ||
+                state is ActionAutomationFailed ||
                 state is LocationFindingFailed ||
                 state is ConversionState.HasSmallLoadingIndicator
         },
@@ -106,76 +108,61 @@ fun ResultSuccessMessage(
         animationsEnabled = animationsEnabled,
     ) { targetState ->
         when (targetState) {
-            is ActionWaiting if targetState.action.output is Output.HasAutomationDelay ->
-                (targetState.action.output as? Output.HasAutomationDelay)?.let { output ->
-                    ResultMessageRow {
-                        LaunchedEffect(targetState.action) {
-                            counterSec = targetState.delay.toInt(DurationUnit.SECONDS)
-                            while (counterSec > 0) {
-                                delay(1.seconds)
-                                counterSec--
-                            }
-                        }
-                        ResultMessageText(
-                            output.automationWaitingText(counterSec, appDetails),
-                            Modifier.testTag("geoShareResultSuccessAutomationCounter"),
-                        )
-                        FilledIconButton(
-                            onCancel,
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.tertiary,
-                                contentColor = MaterialTheme.colorScheme.onTertiary,
-                            ),
-                        ) {
-                            Icon(
-                                Icons.Default.Close,
-                                stringResource(R.string.conversion_loading_indicator_cancel),
-                            )
-                        }
+            is ActionWaiting -> ResultMessageRow {
+                LaunchedEffect(targetState.action) {
+                    counterSec = targetState.delay.toInt(DurationUnit.SECONDS)
+                    while (counterSec > 0) {
+                        delay(1.seconds)
+                        counterSec--
                     }
                 }
+                ResultMessageText(
+                    targetState.output.automationWaitingText(counterSec, appDetails),
+                    Modifier.testTag("geoShareResultSuccessAutomationCounter"),
+                )
+                FilledIconButton(
+                    onCancel,
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.tertiary,
+                        contentColor = MaterialTheme.colorScheme.onTertiary,
+                    ),
+                ) {
+                    Icon(
+                        Icons.Default.Close,
+                        stringResource(R.string.conversion_loading_indicator_cancel),
+                    )
+                }
+            }
 
-            is ActionSucceeded if !targetState.isAutomation && targetState.action.output is Output.HasSuccessText ->
-                (targetState.action.output as? Output.HasSuccessText)?.let { output ->
-                    ResultMessageRow {
-                        ResultMessageText(
-                            output.successText(appDetails),
-                            Modifier.testTag("geoShareResultSuccessMessage"),
-                        )
-                    }
-                }
+            is ActionSucceeded -> ResultMessageRow {
+                ResultMessageText(
+                    targetState.output.successText(appDetails),
+                    Modifier.testTag("geoShareResultSuccessMessage"),
+                )
+            }
 
-            is ActionFailed if !targetState.isAutomation && targetState.action.output is Output.HasErrorText ->
-                (targetState.action.output as? Output.HasErrorText)?.let { output ->
-                    ResultMessageRow {
-                        ResultMessageText(
-                            output.errorText(appDetails),
-                            containerColor = MaterialTheme.colorScheme.errorContainer,
-                            contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                        )
-                    }
-                }
+            is ActionFailed -> ResultMessageRow {
+                ResultMessageText(
+                    targetState.output.errorText(appDetails),
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
 
-            is ActionSucceeded if targetState.isAutomation && targetState.action.output is Output.HasAutomationSuccessText ->
-                (targetState.action.output as? Output.HasAutomationSuccessText)?.let { output ->
-                    ResultMessageRow {
-                        ResultMessageText(
-                            output.automationSuccessText(appDetails),
-                            Modifier.testTag("geoShareResultSuccessMessage"),
-                        )
-                    }
-                }
+            is ActionAutomationSucceeded -> ResultMessageRow {
+                ResultMessageText(
+                    targetState.output.automationSuccessText(appDetails),
+                    Modifier.testTag("geoShareResultSuccessMessage"),
+                )
+            }
 
-            is ActionFailed if targetState.isAutomation && targetState.action.output is Output.HasAutomationErrorText ->
-                (targetState.action.output as? Output.HasAutomationErrorText)?.let { output ->
-                    ResultMessageRow {
-                        ResultMessageText(
-                            output.automationErrorText(appDetails),
-                            containerColor = MaterialTheme.colorScheme.errorContainer,
-                            contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                        )
-                    }
-                }
+            is ActionAutomationFailed -> ResultMessageRow {
+                ResultMessageText(
+                    targetState.output.automationErrorText(appDetails),
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
 
             is LocationFindingFailed -> ResultMessageRow {
                 ResultMessageText(
@@ -287,16 +274,12 @@ private fun ActionFinishedPreview() {
     AppTheme {
         Surface {
             val context = LocalContext.current
-            val geometries = Geometries(context)
-            val coordinateConverter = CoordinateConverter(geometries)
             @SuppressLint("LocalContextGetResourceValueCall")
             ResultSuccessMessage(
                 currentState = ActionFinished(
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
-                    isAutomation = true,
+                    actionResult = ActionResult.Succeeded,
                 ),
                 appDetails = mapOf(
                     PackageNames.OSMAND_PLUS to AppDetail(
@@ -325,16 +308,12 @@ private fun DarkActionFinishedPreview() {
     AppTheme {
         Surface {
             val context = LocalContext.current
-            val geometries = Geometries(context)
-            val coordinateConverter = CoordinateConverter(geometries)
             @SuppressLint("LocalContextGetResourceValueCall")
             ResultSuccessMessage(
                 currentState = ActionFinished(
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
-                    isAutomation = true,
+                    actionResult = ActionResult.Succeeded,
                 ),
                 appDetails = mapOf(
                     PackageNames.OSMAND_PLUS to AppDetail(
@@ -364,16 +343,12 @@ private fun ActionFinishedFeatureNotAvailablePreview() {
         Surface {
             Column {
                 val context = LocalContext.current
-                val geometries = Geometries(context)
-                val coordinateConverter = CoordinateConverter(geometries)
                 @SuppressLint("LocalContextGetResourceValueCall")
                 ResultSuccessMessage(
                     currentState = ActionFinished(
                         source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                         points = persistentListOf(WGS84Point(NaivePoint.example)),
-                        action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                            .toAction(WGS84Point(NaivePoint.example)),
-                        isAutomation = true,
+                        actionResult = ActionResult.Succeeded,
                     ),
                     appDetails = mapOf(
                         PackageNames.OSMAND_PLUS to AppDetail(
@@ -400,16 +375,12 @@ private fun DarkActionFinishedFeatureNotAvailablePreview() {
         Surface {
             Column {
                 val context = LocalContext.current
-                val geometries = Geometries(context)
-                val coordinateConverter = CoordinateConverter(geometries)
                 @SuppressLint("LocalContextGetResourceValueCall")
                 ResultSuccessMessage(
                     currentState = ActionFinished(
                         source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                         points = persistentListOf(WGS84Point(NaivePoint.example)),
-                        action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                            .toAction(WGS84Point(NaivePoint.example)),
-                        isAutomation = true,
+                        actionResult = ActionResult.Succeeded,
                     ),
                     appDetails = mapOf(
                         PackageNames.OSMAND_PLUS to AppDetail(
@@ -441,6 +412,7 @@ private fun ActionWaitingPreview() {
             val outputRepository = OutputRepository(
                 coordinateConverter = coordinateConverter,
             )
+            val output = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
             @SuppressLint("LocalContextGetResourceValueCall")
             ResultSuccessMessage(
                 currentState = ActionWaiting(
@@ -453,8 +425,8 @@ private fun ActionWaitingPreview() {
                     ),
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
+                    action = output.toAction(WGS84Point(NaivePoint.example)),
+                    output = output,
                     isAutomation = true,
                     delay = 3.seconds,
                 ),
@@ -491,6 +463,7 @@ private fun DarkActionWaitingPreview() {
             val outputRepository = OutputRepository(
                 coordinateConverter = coordinateConverter,
             )
+            val output = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
             @SuppressLint("LocalContextGetResourceValueCall")
             ResultSuccessMessage(
                 currentState = ActionWaiting(
@@ -503,8 +476,8 @@ private fun DarkActionWaitingPreview() {
                     ),
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
+                    action = output.toAction(WGS84Point(NaivePoint.example)),
+                    output = output,
                     isAutomation = true,
                     delay = 3.seconds,
                 ),
@@ -640,9 +613,8 @@ private fun SucceededPreview() {
                 currentState = ActionSucceeded(
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
-                    isAutomation = true,
+                    output = SavePointsGpxOutput(coordinateConverter),
+                    actionResult = ActionResult.Succeeded,
                 ),
                 appDetails = mapOf(
                     PackageNames.OSMAND_PLUS to AppDetail(
@@ -678,85 +650,8 @@ private fun DarSucceededPreview() {
                 currentState = ActionSucceeded(
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
-                    isAutomation = true,
-                ),
-                appDetails = mapOf(
-                    PackageNames.OSMAND_PLUS to AppDetail(
-                        "OsmAnd",
-                        context.getDrawable(R.mipmap.ic_launcher_round)!!
-                    ),
-                ),
-                billingFeatures = listOf(AutomationFeature, CustomLinkFeature),
-                billingStatus = BillingStatus.Purchased(
-                    BillingProduct("test", BillingProduct.Type.DONATION),
-                    expired = false,
-                    refundable = true,
-                    token = "test_purchased",
-                ),
-                animationsEnabled = false,
-                onCancel = {},
-                onNavigateToUserPreferencesAutomationScreen = {},
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun SucceededNoMessagePreview() {
-    AppTheme {
-        Surface {
-            val context = LocalContext.current
-            val geometries = Geometries(context)
-            val coordinateConverter = CoordinateConverter(geometries)
-            @SuppressLint("LocalContextGetResourceValueCall")
-            ResultSuccessMessage(
-                currentState = ActionSucceeded(
-                    source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
-                    points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = SharePointsGpxOutput(coordinateConverter)
-                        .toAction(persistentListOf(WGS84Point(NaivePoint.example))),
-                    isAutomation = false,
-                ),
-                appDetails = mapOf(
-                    PackageNames.OSMAND_PLUS to AppDetail(
-                        "OsmAnd",
-                        context.getDrawable(R.mipmap.ic_launcher_round)!!
-                    ),
-                ),
-                billingFeatures = listOf(AutomationFeature, CustomLinkFeature),
-                billingStatus = BillingStatus.Purchased(
-                    BillingProduct("test", BillingProduct.Type.DONATION),
-                    expired = false,
-                    refundable = true,
-                    token = "test_purchased",
-                ),
-                animationsEnabled = false,
-                onCancel = {},
-                onNavigateToUserPreferencesAutomationScreen = {},
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Composable
-private fun DarkSucceededNoMessagePreview() {
-    AppTheme {
-        Surface {
-            val context = LocalContext.current
-            val geometries = Geometries(context)
-            val coordinateConverter = CoordinateConverter(geometries)
-            @SuppressLint("LocalContextGetResourceValueCall")
-            ResultSuccessMessage(
-                currentState = ActionSucceeded(
-                    source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
-                    points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = SharePointsGpxOutput(coordinateConverter)
-                        .toAction(persistentListOf(WGS84Point(NaivePoint.example))),
-                    isAutomation = false,
+                    output = SavePointsGpxOutput(coordinateConverter),
+                    actionResult = ActionResult.Succeeded,
                 ),
                 appDetails = mapOf(
                     PackageNames.OSMAND_PLUS to AppDetail(
@@ -792,9 +687,8 @@ private fun FailedPreview() {
                 currentState = ActionFailed(
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
-                    isAutomation = true,
+                    output = SavePointsGpxOutput(coordinateConverter),
+                    actionResult = ActionResult.Failed,
                 ),
                 appDetails = mapOf(
                     PackageNames.OSMAND_PLUS to AppDetail(
@@ -830,9 +724,8 @@ private fun DarkFailedPreview() {
                 currentState = ActionFailed(
                     source = "https://maps.app.goo.gl/TmbeHMiLEfTBws9EA",
                     points = persistentListOf(WGS84Point(NaivePoint.example)),
-                    action = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
-                        .toAction(WGS84Point(NaivePoint.example)),
-                    isAutomation = true,
+                    output = SavePointsGpxOutput(coordinateConverter),
+                    actionResult = ActionResult.Failed,
                 ),
                 appDetails = mapOf(
                     PackageNames.OSMAND_PLUS to AppDetail(

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionFailedTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionFailedTest.kt
@@ -6,23 +6,30 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.kotlin.mock
+import page.ooooo.geoshare.lib.android.PackageNames
+import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
-import page.ooooo.geoshare.lib.outputs.NoopAction
+import page.ooooo.geoshare.lib.outputs.ActionResult
+import page.ooooo.geoshare.lib.outputs.OpenDisplayGeoUriOutput
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
 class ActionFailedTest {
+    private val coordinateConverter: CoordinateConverter = mock()
+
     @Test
     fun transition_whenExecutionIsNotCancelled_waitsAndReturnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionFailed(source, points, action, isAutomation = true)
+        val output = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
+        val actionResult = ActionResult.Failed
+        val state = ActionFailed(source, points, actionResult, output)
         val workDuration = testScheduler.timeSource.measureTime {
             assertEquals(
-                ActionFinished(source, points, action, isAutomation = true),
+                ActionFinished(source, points, actionResult),
                 state.transition(),
             )
         }
@@ -33,8 +40,9 @@ class ActionFailedTest {
     fun transition_whenExecutionIsCancelled_returnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionFailed(source, points, action, isAutomation = true)
+        val output = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
+        val actionResult = ActionResult.Failed
+        val state = ActionFailed(source, points, actionResult, output)
         var res: State? = null
         val job = launch {
             res = state.transition()
@@ -48,7 +56,7 @@ class ActionFailedTest {
         }
         assertEquals(
             res,
-            ActionFinished(source, points, action, isAutomation = true),
+            ActionFinished(source, points, actionResult),
         )
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionFinishedTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionFinishedTest.kt
@@ -6,15 +6,14 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
-import page.ooooo.geoshare.lib.outputs.NoopAction
+import page.ooooo.geoshare.lib.outputs.ActionResult
 
 class ActionFinishedTest {
     @Test
     fun transition_returnsNull() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionFinished(source, points, action, isAutomation = true)
+        val state = ActionFinished(source, points, ActionResult.SucceededAndFinish)
         assertNull(state.transition())
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionRanTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionRanTest.kt
@@ -6,41 +6,46 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import page.ooooo.geoshare.lib.outputs.NoopAction
 
 class ActionRanTest {
     @Test
-    fun transition_whenSuccessIsTrue_returnsActionSucceeded() = runTest {
+    fun transition_whenActionResultIsSucceededAndOutputDoesNotHaveAnySuccessText_returnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val action = NoopAction
-        val state = ActionRan(source, points, action, isAutomation = true, success = true)
+        val actionResult = ActionResult.Succeeded
+        val state = ActionRan(source, points, action, actionResult, isAutomation = true)
         assertEquals(
-            ActionSucceeded(source, points, action, isAutomation = true),
+            ActionFinished(source, points, actionResult),
             state.transition(),
         )
     }
 
     @Test
-    fun transition_whenSuccessIsFalse_returnsActionFailed() = runTest {
-        val source = "https://maps.google.com/foo"
-        val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionRan(source, points, action, isAutomation = true, success = false)
-        assertEquals(
-            ActionFailed(source, points, action, isAutomation = true),
-            state.transition(),
-        )
-    }
+    fun transition_whenActionResultIsSucceededAndFinishAndOutputDoesNotHaveAnySuccessText_returnsActionFinished() =
+        runTest {
+            val source = "https://maps.google.com/foo"
+            val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
+            val action = NoopAction
+            val actionResult = ActionResult.SucceededAndFinish
+            val state = ActionRan(source, points, action, actionResult, isAutomation = true)
+            assertEquals(
+                ActionFinished(source, points, actionResult),
+                state.transition(),
+            )
+        }
 
     @Test
-    fun transition_whenSuccessIsNull_returnsActionFinished() = runTest {
+    fun transition_whenActionResultIsFailedAndOutputDoesNotHaveAnyErrorText_returnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val action = NoopAction
-        val state = ActionRan(source, points, action, isAutomation = true, success = null)
+        val actionResult = ActionResult.Failed
+        val state = ActionRan(source, points, action, actionResult, isAutomation = true)
         assertEquals(
-            ActionFinished(source, points, action, isAutomation = true),
+            ActionFinished(source, points, actionResult),
             state.transition(),
         )
     }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionRanTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionRanTest.kt
@@ -4,49 +4,78 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.kotlin.mock
+import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
 import page.ooooo.geoshare.lib.outputs.ActionResult
 import page.ooooo.geoshare.lib.outputs.NoopAction
+import page.ooooo.geoshare.lib.outputs.SavePointsGpxOutput
 
 class ActionRanTest {
+    private val coordinateConverter: CoordinateConverter = mock()
+    private val source = "https://maps.google.com/foo"
+    private val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
+
     @Test
-    fun transition_whenActionResultIsSucceededAndOutputDoesNotHaveAnySuccessText_returnsActionFinished() = runTest {
-        val source = "https://maps.google.com/foo"
-        val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val actionResult = ActionResult.Succeeded
-        val state = ActionRan(source, points, action, actionResult, isAutomation = true)
+    fun transition_whenAutomationIsFalseAndResultIsSucceeded_returnsActionSucceededOrFinished() = runTest {
+        for (actionResult in setOf(ActionResult.Succeeded, ActionResult.SucceededAndFinish)) {
+            val output = SavePointsGpxOutput(coordinateConverter)
+            val action = output.toAction(points)
+            assertEquals(
+                ActionSucceeded(source, points, actionResult, output),
+                ActionRan(source, points, action, actionResult, isAutomation = false).transition(),
+            )
+            assertEquals(
+                ActionFinished(source, points, actionResult),
+                ActionRan(source, points, NoopAction, actionResult, isAutomation = false).transition(),
+            )
+        }
+    }
+
+    @Test
+    fun transition_whenAutomationIsFalseAndResultIsFailed_returnsActionFailedOrFinished() = runTest {
+        val output = SavePointsGpxOutput(coordinateConverter)
+        val action = output.toAction(points)
+        val actionResult = ActionResult.Failed
+        assertEquals(
+            ActionFailed(source, points, actionResult, output),
+            ActionRan(source, points, action, actionResult, isAutomation = false).transition(),
+        )
         assertEquals(
             ActionFinished(source, points, actionResult),
-            state.transition(),
+            ActionRan(source, points, NoopAction, actionResult, isAutomation = false).transition(),
         )
     }
 
     @Test
-    fun transition_whenActionResultIsSucceededAndFinishAndOutputDoesNotHaveAnySuccessText_returnsActionFinished() =
-        runTest {
-            val source = "https://maps.google.com/foo"
-            val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-            val action = NoopAction
-            val actionResult = ActionResult.SucceededAndFinish
-            val state = ActionRan(source, points, action, actionResult, isAutomation = true)
+    fun transition_whenAutomationIsTrueAndResultIsSucceeded_returnsActionAutomationSucceededOrFinished() = runTest {
+        for (actionResult in setOf(ActionResult.Succeeded, ActionResult.SucceededAndFinish)) {
+            val output = SavePointsGpxOutput(coordinateConverter)
+            val action = output.toAction(points)
+            assertEquals(
+                ActionAutomationSucceeded(source, points, actionResult, output),
+                ActionRan(source, points, action, actionResult, isAutomation = true).transition(),
+            )
             assertEquals(
                 ActionFinished(source, points, actionResult),
-                state.transition(),
+                ActionRan(source, points, NoopAction, actionResult, isAutomation = true).transition(),
             )
         }
+    }
 
     @Test
-    fun transition_whenActionResultIsFailedAndOutputDoesNotHaveAnyErrorText_returnsActionFinished() = runTest {
-        val source = "https://maps.google.com/foo"
-        val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
+    fun transition_whenAutomationIsTrueAndResultIsFailed_returnsActionAutomationFailedOrFinished() = runTest {
+        val output = SavePointsGpxOutput(coordinateConverter)
+        val action = output.toAction(points)
         val actionResult = ActionResult.Failed
-        val state = ActionRan(source, points, action, actionResult, isAutomation = true)
+        assertEquals(
+            ActionAutomationFailed(source, points, actionResult, output),
+            ActionRan(source, points, action, actionResult, isAutomation = true).transition(),
+        )
         assertEquals(
             ActionFinished(source, points, actionResult),
-            state.transition(),
+            ActionRan(source, points, NoopAction, actionResult, isAutomation = true).transition(),
         )
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionSucceededTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionSucceededTest.kt
@@ -6,23 +6,29 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.kotlin.mock
+import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
-import page.ooooo.geoshare.lib.outputs.NoopAction
+import page.ooooo.geoshare.lib.outputs.ActionResult
+import page.ooooo.geoshare.lib.outputs.SavePointsGpxOutput
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
 class ActionSucceededTest {
+    private val coordinateConverter: CoordinateConverter = mock()
+
     @Test
     fun transition_whenExecutionIsNotCancelled_waitsAndReturnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionSucceeded(source, points, action, isAutomation = true)
+        val output = SavePointsGpxOutput(coordinateConverter)
+        val actionResult = ActionResult.SucceededAndFinish
+        val state = ActionSucceeded(source, points, actionResult, output)
         val workDuration = testScheduler.timeSource.measureTime {
             assertEquals(
-                ActionFinished(source, points, action, isAutomation = true),
+                ActionFinished(source, points, actionResult),
                 state.transition(),
             )
         }
@@ -33,8 +39,9 @@ class ActionSucceededTest {
     fun transition_whenExecutionIsCancelled_returnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionSucceeded(source, points, action, isAutomation = true)
+        val output = SavePointsGpxOutput(coordinateConverter)
+        val actionResult = ActionResult.SucceededAndFinish
+        val state = ActionSucceeded(source, points, actionResult, output)
         var res: State? = null
         val job = launch {
             res = state.transition()
@@ -48,7 +55,7 @@ class ActionSucceededTest {
         }
         assertEquals(
             res,
-            ActionFinished(source, points, action, isAutomation = true),
+            ActionFinished(source, points, actionResult),
         )
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionWaitingTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/ActionWaitingTest.kt
@@ -7,22 +7,27 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.kotlin.mock
+import page.ooooo.geoshare.lib.android.PackageNames
+import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
-import page.ooooo.geoshare.lib.outputs.NoopAction
+import page.ooooo.geoshare.lib.outputs.ActionResult
+import page.ooooo.geoshare.lib.outputs.OpenDisplayGeoUriOutput
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
 class ActionWaitingTest {
+    private val coordinateConverter: CoordinateConverter = mock()
     private val stateContext: ConversionStateContext = mock()
 
     @Test
     fun transition_whenExecutionIsNotCancelled_waitsAndReturnsActionReady() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionWaiting(stateContext, source, points, action, isAutomation = true, 3.seconds)
+        val output = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
+        val action = output.toAction(points.last())
+        val state = ActionWaiting(stateContext, source, points, action, output, isAutomation = true, 3.seconds)
         val workDuration = testScheduler.timeSource.measureTime {
             assertEquals(
                 ActionReady(source, points, action, isAutomation = true),
@@ -36,8 +41,9 @@ class ActionWaitingTest {
     fun transition_whenExecutionIsNotCancelledAndDelayIsNotPositive_doesNotWaitAndReturnsActionReady() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionWaiting(stateContext, source, points, action, isAutomation = true, (-1).seconds)
+        val output = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
+        val action = output.toAction(points.last())
+        val state = ActionWaiting(stateContext, source, points, action, output, isAutomation = true, (-1).seconds)
         val workDuration = testScheduler.timeSource.measureTime {
             assertEquals(
                 ActionReady(source, points, action, isAutomation = true),
@@ -51,8 +57,9 @@ class ActionWaitingTest {
     fun transition_whenExecutionIsCancelled_returnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = NoopAction
-        val state = ActionWaiting(stateContext, source, points, action, isAutomation = true, 3.seconds)
+        val output = OpenDisplayGeoUriOutput(PackageNames.OSMAND_PLUS, coordinateConverter)
+        val action = output.toAction(points.last())
+        val state = ActionWaiting(stateContext, source, points, action, output, isAutomation = true, 3.seconds)
         var res: State? = null
         val job = launch {
             res = state.transition()
@@ -66,7 +73,7 @@ class ActionWaitingTest {
         }
         assertEquals(
             res,
-            ActionFinished(source, points, action, isAutomation = true),
+            ActionFinished(source, points, ActionResult.Failed),
         )
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/ConversionSucceededTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/ConversionSucceededTest.kt
@@ -427,7 +427,8 @@ class ConversionSucceededTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val automation = OpenDisplayGeoUriAutomation(PackageNames.GOOGLE_MAPS)
-        val action = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter).toAction(points.last())
+        val output = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
+        val action = output.toAction(points.last())
         val delay = 2.seconds
         val billing: Billing = mock {
             on { status } doReturn MutableStateFlow(
@@ -454,7 +455,7 @@ class ConversionSucceededTest {
         }
         val state = ConversionSucceeded(stateContext, source, points)
         assertEquals(
-            ActionWaiting(stateContext, source, points, action, isAutomation = true, delay = delay),
+            ActionWaiting(stateContext, source, points, action, output, isAutomation = true, delay = delay),
             state.transition(),
         )
     }
@@ -464,7 +465,8 @@ class ConversionSucceededTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val automation = ShareLinkUriAutomation(FakeGoogleMapsDisplayLink.uuid)
-        val action = ShareLinkUriOutput(FakeGoogleMapsDisplayLink, coordinateConverter).toAction(points.last())
+        val output = ShareLinkUriOutput(FakeGoogleMapsDisplayLink, coordinateConverter)
+        val action = output.toAction(points.last())
         val delay = 2.seconds
         val billing: Billing = mock {
             on { status } doReturn MutableStateFlow(
@@ -491,7 +493,7 @@ class ConversionSucceededTest {
         }
         val state = ConversionSucceeded(stateContext, source, points)
         assertEquals(
-            ActionWaiting(stateContext, source, points, action, isAutomation = true, delay = delay),
+            ActionWaiting(stateContext, source, points, action, output, isAutomation = true, delay = delay),
             state.transition(),
         )
     }
@@ -534,7 +536,8 @@ class ConversionSucceededTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val automation = SavePointsGpxAutomation
-        val action = SavePointsGpxOutput(coordinateConverter).toAction(points)
+        val output = SavePointsGpxOutput(coordinateConverter)
+        val action = output.toAction(points)
         val delay = 2.seconds
         val billing: Billing = mock {
             on { status } doReturn MutableStateFlow(
@@ -561,7 +564,7 @@ class ConversionSucceededTest {
         }
         val state = ConversionSucceeded(stateContext, source, points)
         assertEquals(
-            ActionWaiting(stateContext, source, points, action, isAutomation = true, delay = delay),
+            ActionWaiting(stateContext, source, points, action, output, isAutomation = true, delay = delay),
             state.transition(),
         )
     }
@@ -571,7 +574,8 @@ class ConversionSucceededTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val automation = OpenDisplayGeoUriAutomation(PackageNames.GOOGLE_MAPS)
-        val action = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter).toAction(points.last())
+        val output = OpenDisplayGeoUriOutput(PackageNames.GOOGLE_MAPS, coordinateConverter)
+        val action = output.toAction(points.last())
         val delay = 2.seconds
         val billing: Billing = mock {
             on { status } doReturn MutableStateFlow(
@@ -598,7 +602,7 @@ class ConversionSucceededTest {
         }
         val state = ConversionSucceeded(stateContext, source, points)
         assertEquals(
-            ActionWaiting(stateContext, source, points, action, isAutomation = true, delay = delay),
+            ActionWaiting(stateContext, source, points, action, output, isAutomation = true, delay = delay),
             state.transition(),
         )
     }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/LocationFindingFailedTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/LocationFindingFailedTest.kt
@@ -6,28 +6,23 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.Mockito.mock
-import page.ooooo.geoshare.lib.android.PackageNames
-import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
-import page.ooooo.geoshare.lib.outputs.OpenRouteOnePointGpxOutput
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
 class LocationFindingFailedTest {
-    private val coordinateConverter: CoordinateConverter = mock()
-
     @Test
     fun locationFindingFailed_executionIsNotCancelled_waitsAndReturnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = OpenRouteOnePointGpxOutput(PackageNames.TOMTOM, coordinateConverter).toAction(points.last())
-        val state = LocationFindingFailed(source, points, action, isAutomation = false)
+        val actionResult = ActionResult.Failed
+        val state = LocationFindingFailed(source, points, actionResult)
         val workDuration = testScheduler.timeSource.measureTime {
             assertEquals(
-                ActionFinished(source, points, action, isAutomation = false),
+                ActionFinished(source, points, actionResult),
                 state.transition(),
             )
         }
@@ -38,8 +33,8 @@ class LocationFindingFailedTest {
     fun locationFindingFailed_executionIsCancelled_returnsActionFinished() = runTest {
         val source = "https://maps.google.com/foo"
         val points = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
-        val action = OpenRouteOnePointGpxOutput(PackageNames.TOMTOM, coordinateConverter).toAction(points.last())
-        val state = LocationFindingFailed(source, points, action, isAutomation = false)
+        val actionResult = ActionResult.Failed
+        val state = LocationFindingFailed(source, points, actionResult)
         var res: State? = null
         val job = launch {
             res = state.transition()
@@ -53,7 +48,7 @@ class LocationFindingFailedTest {
         }
         assertEquals(
             res,
-            ActionFinished(source, points, action, isAutomation = false),
+            ActionFinished(source, points, actionResult),
         )
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/LocationRationaleShownTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/LocationRationaleShownTest.kt
@@ -9,6 +9,7 @@ import page.ooooo.geoshare.lib.android.PackageNames
 import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import page.ooooo.geoshare.lib.outputs.OpenRouteOnePointGpxOutput
 
 class LocationRationaleShownTest {
@@ -33,7 +34,7 @@ class LocationRationaleShownTest {
         val action = OpenRouteOnePointGpxOutput(PackageNames.TOMTOM, coordinateConverter).toAction(points.last())
         val state = LocationRationaleShown(source, points, action, isAutomation = false)
         assertEquals(
-            ActionFinished(source, points, action, isAutomation = false),
+            ActionFinished(source, points, ActionResult.Failed),
             state.deny(false),
         )
     }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/LocationReceivedTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/LocationReceivedTest.kt
@@ -9,6 +9,7 @@ import page.ooooo.geoshare.lib.android.PackageNames
 import page.ooooo.geoshare.lib.geo.CoordinateConverter
 import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.geo.WGS84Point
+import page.ooooo.geoshare.lib.outputs.ActionResult
 import page.ooooo.geoshare.lib.outputs.OpenRouteOnePointGpxOutput
 
 class LocationReceivedTest {
@@ -21,7 +22,7 @@ class LocationReceivedTest {
         val action = OpenRouteOnePointGpxOutput(PackageNames.TOMTOM, coordinateConverter).toAction(points.last())
         val state = LocationReceived(source, points, action, isAutomation = false, location = null)
         assertEquals(
-            LocationFindingFailed(source, points, action, isAutomation = false),
+            LocationFindingFailed(source, points, ActionResult.Failed),
             state.transition(),
         )
     }

--- a/app/src/test/java/page/ooooo/geoshare/lib/outputs/OpenPointsGpxOutputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/outputs/OpenPointsGpxOutputTest.kt
@@ -4,7 +4,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -55,11 +54,11 @@ class OpenPointsGpxOutputTest : GeoTest {
             setOf(oldFile.path),
             childDir.listFiles()?.map { it.path }?.toSet(),
         )
-        val success = OpenPointsGpxOutput(PackageNames.TEST, coordinateConverter).execute(
+        val actionResult = OpenPointsGpxOutput(PackageNames.TEST, coordinateConverter).execute(
             value = points,
             actionContext = mockActionContext(parentDir),
         )
-        assertTrue(success)
+        assertEquals(ActionResult.SucceededAndFinish, actionResult)
         val resFiles = childDir.listFiles()
         assertEquals(1, resFiles?.size)
         val resFile = resFiles?.first()

--- a/app/src/test/java/page/ooooo/geoshare/lib/outputs/OpenRouteOnePointGpxOutputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/outputs/OpenRouteOnePointGpxOutputTest.kt
@@ -3,7 +3,6 @@ package page.ooooo.geoshare.lib.outputs
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -40,28 +39,28 @@ class OpenRouteOnePointGpxOutputTest : GeoTest {
         )
 
     @Test
-    fun execute_locationIsNull_returnsFalse() = runTest {
+    fun execute_locationIsNull_returnsFailed() = runTest {
         val parentDir = createTempDirectory().toFile()
-        val success = OpenRouteOnePointGpxOutput(PackageNames.TEST, coordinateConverter).execute(
+        val actionResult = OpenRouteOnePointGpxOutput(PackageNames.TEST, coordinateConverter).execute(
             location = null,
             value = WGS84Point(1.0, 2.0, name = "My destination", source = Source.GENERATED),
             actionContext = mockActionContext(parentDir),
         )
-        assertFalse(success)
+        assertEquals(ActionResult.Failed, actionResult)
     }
 
     @Test
-    fun execute_parentDirIsNotWritable_returnsFalse() = runTest {
+    fun execute_parentDirIsNotWritable_returnsFailed() = runTest {
         val parentDir = createTempDirectory(
             null,
             PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("r--------")),
         ).toFile()
-        val success = OpenRouteOnePointGpxOutput(PackageNames.TEST, coordinateConverter).execute(
+        val actionResult = OpenRouteOnePointGpxOutput(PackageNames.TEST, coordinateConverter).execute(
             location = WGS84Point(3.0, 4.0, source = Source.GPS_SENSOR),
             value = WGS84Point(1.0, 2.0, name = "My destination", source = Source.GENERATED),
             actionContext = mockActionContext(parentDir),
         )
-        assertFalse(success)
+        assertEquals(ActionResult.Failed, actionResult)
     }
 
     @Test
@@ -75,12 +74,12 @@ class OpenRouteOnePointGpxOutputTest : GeoTest {
             setOf(oldFile.path),
             childDir.listFiles()?.map { it.path }?.toSet(),
         )
-        val success = OpenRouteOnePointGpxOutput(PackageNames.TEST, coordinateConverter).execute(
+        val actionResult = OpenRouteOnePointGpxOutput(PackageNames.TEST, coordinateConverter).execute(
             location = WGS84Point(3.0, 4.0, source = Source.GPS_SENSOR),
             value = WGS84Point(1.0, 2.0, name = "My destination", source = Source.GENERATED),
             actionContext = mockActionContext(parentDir),
         )
-        assertTrue(success)
+        assertEquals(ActionResult.SucceededAndFinish, actionResult)
         val resFiles = childDir.listFiles()
         assertEquals(1, resFiles?.size)
         val resFile = resFiles?.first()

--- a/fastlane/metadata/android/en-US/changelogs/42.txt
+++ b/fastlane/metadata/android/en-US/changelogs/42.txt
@@ -2,4 +2,5 @@
 - Added the option to save a point to a contact.
 - Fixed pin display when opening Cartes IGN.
 - Fixed splash screen in dark mode.
+- Improved link sharing workflow by closing GeoShare after opening another map app.
 - Improved network error messages.


### PR DESCRIPTION
And after sharing data with the Android system, e.g. sharing a geo: URI, sharing a GPX file, opening a web map URL.

Do not close it after copying coordinates or after saving a file.

Do not close it when a link was entered in the main form. Only close it when it was shared with the app.

Fixes: #366