### PR TITLE
Fix Baidu Map coordinate offset toward East

### DIFF
--- a/app/src/androidTest/java/page/ooooo/geoshare/BehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/BehaviorTest.kt
@@ -170,6 +170,7 @@ interface BehaviorTest {
         assumeTrue("This test only works when DNS resolves the domain $domain", success)
     }
 
+    @Suppress("unused")
     suspend fun assumeHttpHeadIsSuccess(@Suppress("SameParameterValue") url: String) {
         val status = try {
             withContext(Dispatchers.IO) {

--- a/app/src/androidTest/java/page/ooooo/geoshare/inputs/BaiduMapInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/inputs/BaiduMapInputBehaviorTest.kt
@@ -98,30 +98,28 @@ class BaiduMapInputBehaviorTest : InputBehaviorTest {
     fun baiduMapHtml() = uiAutomator {
         runBlocking {
             assumeDomainResolvable("map.baidu.com")
-            assumeHttpHeadIsSuccess("https://maponline1.bdimg.com/tile/?qt=vtile&x=13490&y=6210&z=14&styles=pl&udt=20230101&scaler=1&p=1")
+            // TODO Remove the whole assumeHttpHeadIsSuccess function, because the HTTP HEAD check seems to always fail but the test works anyway
+            // assumeHttpHeadIsSuccess("https://maponline1.bdimg.com/tile/?qt=vtile&x=13490&y=6210&z=14&styles=pl&udt=20230101&scaler=1&p=1")
         }
 
         // Shared coordinates
         testUri(
-            BD09MCPoint(3619117.0, 13392243.0, 17.0, name = "地图上的点", source = Source.URI),
-            "https://j.map.baidu.com/64/lqEk", // Resolves to https://map.baidu.com/poi/%E5%9C%B0%E5%9B%BE%E4%B8%8A%E7%9A%84%E7%82%B9/@13392243,3619117,17z...
-            // On desktop, it resolves to https://map.baidu.com/poi/%E5%9C%B0%E5%9B%BE%E4%B8%8A%E7%9A%84%E7%82%B9/@13392211,3619117,17z...
+            BD09MCPoint(3619117.0, 13392211.0, 17.0, name = "地图上的点", source = Source.JAVASCRIPT),
+            "https://j.map.baidu.com/64/lqEk", // Resolves to https://map.baidu.com/poi/%E5%9C%B0%E5%9B%BE%E4%B8%8A%E7%9A%84%E7%82%B9/@13392211,3619117,17z...
             timeoutMs = NETWORK_TIMEOUT * 2,
         )
 
         // Shared POI
         testUri(
-            BD09MCPoint(3316047.58, 13502465.77, 19.0, name = "黄岩客运中心", source = Source.URI),
+            BD09MCPoint(3316047.58, 13502465.77, 19.0, name = "黄岩客运中心", source = Source.JAVASCRIPT),
             "https://j.map.baidu.com/44/lth", // Resolves to https://map.baidu.com/poi/%E9%BB%84%E5%B2%A9%E5%AE%A2%E8%BF%90%E4%B8%AD%E5%BF%83/@13502465.77,3316047.58,19z...
-            // On desktop, it also resolves to https://map.baidu.com/poi/%E9%BB%84%E5%B2%A9%E5%AE%A2%E8%BF%90%E4%B8%AD%E5%BF%83/@13502465.77,3316047.58,19z...
             timeoutMs = NETWORK_TIMEOUT * 2,
         )
 
         // Shared POI that requires CSS
         testUri(
-            BD09MCPoint(3750567.0, 13224572.0, 17.0, name = "地图上的点", source = Source.URI),
-            "https://j.map.baidu.com/a7/GXfM", // Resolves to https://map.baidu.com/poi/%E5%9C%B0%E5%9B%BE%E4%B8%8A%E7%9A%84%E7%82%B9/@13224572,3750567,17z...
-            // On desktop, it resolves to https://map.baidu.com/poi/%E5%9C%B0%E5%9B%BE%E4%B8%8A%E7%9A%84%E7%82%B9/@13224540,3750567,17z...
+            BD09MCPoint(3750567.0, 13224540.0, 17.0, name = "地图上的点", source = Source.JAVASCRIPT),
+            "https://j.map.baidu.com/a7/GXfM", // Resolves to https://map.baidu.com/poi/%E5%9C%B0%E5%9B%BE%E4%B8%8A%E7%9A%84%E7%82%B9/@13224540,3750567,17z...
             timeoutMs = NETWORK_TIMEOUT * 2,
         )
     }

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInput.kt
@@ -51,8 +51,11 @@ object BaiduMapWebViewInput : WebViewInput {
         uriQuote: UriQuote,
         log: Log,
     ) = buildParseResult {
+        val json = Json {
+            explicitNulls = false
+        }
         try {
-            Json.decodeFromString<ExtractedPoint>(data)
+            json.decodeFromString<ExtractedPoint>(data)
         } catch (tr: IllegalArgumentException) {
             log.e(TAG, "Deserialization error", tr)
             null

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInput.kt
@@ -2,17 +2,47 @@ package page.ooooo.geoshare.lib.inputs
 
 import android.webkit.WebSettings
 import androidx.annotation.StringRes
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import page.ooooo.geoshare.R
 import page.ooooo.geoshare.lib.Log
 import page.ooooo.geoshare.lib.UriQuote
+import page.ooooo.geoshare.lib.geo.BD09MCPoint
+import page.ooooo.geoshare.lib.geo.Source
 import page.ooooo.geoshare.lib.network.DefaultNetworkTools
 
 object BaiduMapWebViewInput : WebViewInput {
+
+    @Serializable
+    private data class ExtractedPoint(val lat: Double?, val lon: Double?, val z: Double?, val name: String?)
+
     @StringRes
     override val permissionTitleResId = R.string.converter_baidu_map_permission_title
 
     @StringRes
     override val loadingIndicatorTitleResId = R.string.converter_baidu_map_loading_indicator_title
+
+    // language=JavaScript
+    override val unsafeExtractionJavascript = """
+        () => {
+            function deepGet(obj, ...keys) {
+                return keys.reduce((acc, key) => {
+                    if (acc === null || acc === undefined) return undefined;
+                    return acc[key];
+                }, obj);
+            }
+            const lat =
+                deepGet(window, '_indoorMgr', '_map', 'temp', 'infoWin', 'overlay', 'point', 'lat') ||
+                deepGet(window, '_appStateFromUrl', 'loc', 'y');
+            const lon =
+                deepGet(window, '_indoorMgr', '_map', 'temp', 'infoWin', 'overlay', 'point', 'lng') ||
+                deepGet(window, '_appStateFromUrl', 'loc', 'x');
+            const z = deepGet(window, '_appStateFromUrl', 'loc', 'z');
+            const name = deepGet(window, '_appStateFromUrl', 'wd', 0);
+            return JSON.stringify({ lat, lon, z, name });
+        };
+    """.trimIndent()
 
     override suspend fun parse(
         data: String,
@@ -21,7 +51,14 @@ object BaiduMapWebViewInput : WebViewInput {
         uriQuote: UriQuote,
         log: Log,
     ) = buildParseResult {
-        nextStep = NextStep(BaiduMapUriInput, data)
+        try {
+            Json.decodeFromString<ExtractedPoint>(data)
+        } catch (tr: IllegalArgumentException) {
+            log.e(TAG, "Deserialization error", tr)
+            null
+        }?.run {
+            points = persistentListOf(BD09MCPoint(lat, lon, z, name, source = Source.JAVASCRIPT))
+        }
     }
 
     override fun extendWebSettings(settings: WebSettings) {
@@ -31,11 +68,10 @@ object BaiduMapWebViewInput : WebViewInput {
 
     override fun shouldInterceptRequest(requestUrlString: String) =
         // Assets
-        requestUrlString.endsWith(".ico")
+        requestUrlString.endsWith(".css")
+            || requestUrlString.endsWith(".ico")
             || (requestUrlString.endsWith(".png") && !requestUrlString.contains("/image/api/"))
             || requestUrlString.endsWith("/static/common/images/new/loading")
-            // Notice that we don't block .css, so that links such as https://j.map.baidu.com/a7/GXfM redirect to the
-            // correct URL
 
             // Map tiles
             || requestUrlString.contains(@Suppress("SpellCheckingInspection") "bdimg.com/tile/")
@@ -44,5 +80,7 @@ object BaiduMapWebViewInput : WebViewInput {
             || requestUrlString.contains(@Suppress("SpellCheckingInspection") "/alog.min.js")
             || requestUrlString.contains(@Suppress("SpellCheckingInspection") "map.baidu.com/newmap_test/static/common/images/transparent.gif")
 
-    override fun toString() = "BaiduMapWebViewInput"
+    private const val TAG = "BaiduMapWebViewInput"
+
+    override fun toString() = TAG
 }

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/DebugWebViewInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/DebugWebViewInput.kt
@@ -18,6 +18,11 @@ object DebugWebViewInput : WebViewInput {
     @StringRes
     override val loadingIndicatorTitleResId = R.string.converter_debug_loading_indicator_title
 
+    // language=JavaScript
+    override val unsafeExtractionJavascript = """
+        () => window.location.href !== 'about:blank' ? window.location.href : undefined;
+    """.trimIndent()
+
     override suspend fun parse(
         data: String,
         match: String,

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/GoogleMapsWebViewInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/GoogleMapsWebViewInput.kt
@@ -12,6 +12,11 @@ object GoogleMapsWebViewInput : WebViewInput {
     @StringRes
     override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
 
+    // language=JavaScript
+    override val unsafeExtractionJavascript = """
+        () => window.location.href !== 'about:blank' ? window.location.href : undefined;
+    """.trimIndent()
+
     override suspend fun parse(
         data: String,
         match: String,

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/Input.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/Input.kt
@@ -45,6 +45,8 @@ interface BasicInput<T> : Input<T> {
 }
 
 interface WebViewInput : Input<String>, Input.HasPermission {
+    val unsafeExtractionJavascript: String
+
     fun extendWebSettings(settings: WebSettings) {}
     fun shouldInterceptRequest(requestUrlString: String): Boolean = false
 }

--- a/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
@@ -791,7 +791,8 @@ private fun MainBottomPane(currentState: State) {
             )
             ConversionWebView(
                 unsafeUrl = currentState.match,
-                onUrlChange = { currentState.setData(it) },
+                unsafeExtractionJavascript = currentState.input.unsafeExtractionJavascript,
+                onExtractionSettle = { currentState.setData(it) },
                 extendWebSettings = { currentState.input.extendWebSettings(it) },
                 shouldInterceptRequest = { currentState.input.shouldInterceptRequest(it) },
             )

--- a/app/src/main/java/page/ooooo/geoshare/ui/components/ConversionWebView.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/components/ConversionWebView.kt
@@ -44,13 +44,14 @@ private const val TAG = "ConversionWebView"
 @Composable
 fun ConversionWebView(
     unsafeUrl: String,
+    unsafeExtractionJavascript: String,
+    onExtractionSettle: (data: String) -> Unit,
     extendWebSettings: (settings: WebSettings) -> Unit,
-    onUrlChange: (urlString: String) -> Unit,
     shouldInterceptRequest: (requestUrlString: String) -> Boolean,
     // Set window size minus a common browser chrome size, so the numbers seem real, in case a web page checks
     sizePx: Size = Size(1080 - 2f, 1920f - 277f),
-    urlChangeCheckInterval: Duration = 1.seconds,
-    urlChangeDebounceTimeout: Duration = 3.seconds,
+    extractionInterval: Duration = 1.seconds,
+    settleTimeout: Duration = 3.seconds,
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
@@ -58,27 +59,36 @@ fun ConversionWebView(
 
     // As an extra layer of security, allow only specific URLs to be loaded in the WebView. These URLs should be more
     // strict than the patterns in Input (for example only HTTPS should be allowed) and they should not change often.
-    val googleHostPattern = """(?:www|maps)\.google(?:\.[a-z]{2,3})?\.[a-z]{2,3}"""
-    val baiduHostPattern = """map\.baidu\.com"""
-    val allowUrlPattern = Regex("""^https://(?:$googleHostPattern|$baiduHostPattern)[/?#]\S+$""")
+    val allowedUrlPatterns = listOf(
+        // language=RegExp
+        """^https://(?:www|maps)\.google(?:\.[a-z]{2,3})?\.[a-z]{2,3}[/?#]\S+$""",
+        // language=RegExp
+        """^https://map\.baidu\.com[/?#]\S+$""",
+        // language=RegExp
+        """^https://www\.example\.com[/?#]\S+$""",
+    )
     val safeUrl = remember(unsafeUrl) {
-        allowUrlPattern.matchEntire(unsafeUrl)?.value
+        allowedUrlPatterns.firstNotNullOfOrNull { pattern -> Regex(pattern).matchEntire(unsafeUrl)?.value }
     }
 
-    // Call URL change callback if the URL hasn't changed for a while, because:
-    // 1. First URL change is often not the final URL, and we don't want to start parsing an intermediate URL.
-    // 2. Quick URL changes cause ConversionState transition to crash, because each new transition cancels any running
-    //    transition.
-    val currentUrlStringFlow = remember(safeUrl) { MutableStateFlow<String?>(null) }
-    LaunchedEffect(currentUrlStringFlow) {
-        currentUrlStringFlow
+    // Store the extraction result. Then call the extraction settle callback. Call it only after the result hasn't
+    // changed in a while, because:
+    // 1. The first extraction often doesn't lead to the final result. For example when extracting the page URL, the
+    //    first URL is not the final one. It can take the page a few seconds to set the final page URL.
+    // 2. Quick calls to the settle callback would make a ConversionState transition crash, because each new transition
+    //    cancels any running transition.
+    val dataFlow = remember(safeUrl) { MutableStateFlow<String?>(null) }
+    LaunchedEffect(dataFlow) {
+        dataFlow
             .filterNotNull()
-            .onEach { Log.d(TAG, "URL is $it") }
+            .onEach { data ->
+                Log.d(TAG, "Extracted $data")
+            }
             .distinctUntilChanged()
-            .debounce(urlChangeDebounceTimeout)
-            .collect { urlString ->
-                Log.d(TAG, "URL hasn't changed in $urlChangeDebounceTimeout, calling callback")
-                onUrlChange(urlString)
+            .debounce(settleTimeout)
+            .collect { data ->
+                Log.i(TAG, "Extraction settled at $data after $settleTimeout")
+                onExtractionSettle(data)
             }
     }
 
@@ -114,9 +124,9 @@ fun ConversionWebView(
                 settings.allowContentAccess = false
                 settings.allowFileAccess = false
                 settings.javaScriptEnabled = true
+                // Notice that we don't set custom user agent, because it makes Google Maps serve an error page. An
+                // Input can set a user agent in extendWebSettings, if needed.
                 extendWebSettings(settings)
-
-                // Notice that we don't set custom user agent, because it makes Google Maps serve an error page
 
                 webChromeClient = object : WebChromeClient() {
                     override fun onConsoleMessage(cm: ConsoleMessage): Boolean =
@@ -130,8 +140,8 @@ fun ConversionWebView(
                     object {
                         @Suppress("unused")
                         @JavascriptInterface
-                        fun onUrlChange(urlString: String) {
-                            currentUrlStringFlow.value = urlString
+                        fun onExtract(data: String) {
+                            dataFlow.value = data
                         }
                     },
                     "Android",
@@ -142,9 +152,16 @@ fun ConversionWebView(
                         super.onPageFinished(view, url)
 
                         view?.evaluateJavascript(
-                            """window.setInterval(function () {
-                                Android.onUrlChange(window.location.href);
-                            }, ${urlChangeCheckInterval.inWholeMilliseconds});""".trimIndent(),
+                            // language=JavaScript
+                            """
+                                (() => {
+                                    const extract = $unsafeExtractionJavascript;
+                                    window.setInterval(
+                                        () => Android.onExtract(extract()),
+                                        ${extractionInterval.inWholeMilliseconds}
+                                    );
+                                })();
+                            """.trimIndent(),
                             null,
                         )
                     }
@@ -155,10 +172,10 @@ fun ConversionWebView(
                     ): WebResourceResponse? {
                         request?.url?.toString()?.let { requestUrlString ->
                             if (shouldInterceptRequest(requestUrlString)) {
-                                Log.d(TAG, "Blocked request to $requestUrlString")
+                                Log.d(TAG, "Blocked request $requestUrlString")
                                 return WebResourceResponse("text/plain", "utf-8", null)
                             }
-                            Log.d(TAG, "Allowed request to $requestUrlString")
+                            Log.d(TAG, "Allowed request $requestUrlString")
                         }
                         return super.shouldInterceptRequest(view, request)
                     }

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/PermissionGrantedWebViewInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/PermissionGrantedWebViewInputTest.kt
@@ -45,6 +45,10 @@ class PermissionGrantedWebViewInputTest {
     fun transition_whenSetDataIsCalled_returnsDataParsed() = runTest {
         val source = "https://maps.google.com/foo"
         val input = object : WebViewInput {
+            override val permissionTitleResId = R.string.converter_google_maps_permission_title
+            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
+            override val unsafeExtractionJavascript = "undefined"
+
             override suspend fun parse(
                 data: String,
                 match: String,
@@ -55,9 +59,6 @@ class PermissionGrantedWebViewInputTest {
                 prevResult?.points ?: persistentListOf(),
                 nextStep = NextStep(DebugUriInput, data) // Store data in nextStep, so we can test it
             )
-
-            override val permissionTitleResId = R.string.converter_google_maps_permission_title
-            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
         }
         val prevPoints = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val prevResult = ParseResult(prevPoints)
@@ -95,6 +96,10 @@ class PermissionGrantedWebViewInputTest {
     fun transition_whenSetDataIsNotCalledWithinTimeout_returnsConversionFailed() = runTest {
         val source = "https://maps.google.com/foo"
         val input = object : WebViewInput {
+            override val permissionTitleResId = R.string.converter_google_maps_permission_title
+            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
+            override val unsafeExtractionJavascript = "undefined"
+
             override suspend fun parse(
                 data: String,
                 match: String,
@@ -105,9 +110,6 @@ class PermissionGrantedWebViewInputTest {
                 prevResult?.points ?: persistentListOf(),
                 nextStep = NextStep(DebugUriInput, data) // Store data in nextStep, so we can test it
             )
-
-            override val permissionTitleResId = R.string.converter_google_maps_permission_title
-            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
         }
         val prevPoints = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val prevResult = ParseResult(prevPoints)
@@ -137,6 +139,10 @@ class PermissionGrantedWebViewInputTest {
     fun transition_whenInputParseThrowsCancellationException_returnsConversionFailed() = runTest {
         val source = "https://maps.google.com/foo"
         val input = object : WebViewInput {
+            override val permissionTitleResId = R.string.converter_google_maps_permission_title
+            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
+            override val unsafeExtractionJavascript = "undefined"
+
             override suspend fun parse(
                 data: String,
                 match: String,
@@ -144,9 +150,6 @@ class PermissionGrantedWebViewInputTest {
                 uriQuote: UriQuote,
                 log: Log,
             ) = throw CancellationException()
-
-            override val permissionTitleResId = R.string.converter_google_maps_permission_title
-            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
         }
         val prevPoints = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val prevResult = ParseResult(prevPoints)
@@ -176,6 +179,10 @@ class PermissionGrantedWebViewInputTest {
     fun transition_whenItIsCancelled_returnsConversionFailed() = runTest {
         val source = "https://maps.google.com/foo"
         val input = object : WebViewInput {
+            override val permissionTitleResId = R.string.converter_google_maps_permission_title
+            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
+            override val unsafeExtractionJavascript = "undefined"
+
             override suspend fun parse(
                 data: String,
                 match: String,
@@ -183,9 +190,6 @@ class PermissionGrantedWebViewInputTest {
                 uriQuote: UriQuote,
                 log: Log,
             ) = ParseResult()
-
-            override val permissionTitleResId = R.string.converter_google_maps_permission_title
-            override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
         }
         val prevPoints = persistentListOf(WGS84Point(1.0, 2.0, source = Source.GENERATED))
         val prevResult = ParseResult(prevPoints)

--- a/app/src/test/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInputTest.kt
@@ -1,17 +1,149 @@
 package page.ooooo.geoshare.lib.inputs
 
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import page.ooooo.geoshare.lib.FakeLog
+import page.ooooo.geoshare.lib.geo.BD09MCPoint
+import page.ooooo.geoshare.lib.geo.Source
 
 class BaiduMapWebViewInputTest : InputTest {
     private val input = BaiduMapWebViewInput
 
     @Test
-    fun parse_returnsNextStep() = runTest {
+    fun parse_whenDataIsValidJsonObject_returnsPoint() = runTest {
         assertEquals(
-            ParseResult(nextStep = NextStep(BaiduMapUriInput, "https://map.baidu.com/redirected")),
-            input.parse("https://map.baidu.com/redirected", "https://map.baidu.com/original"),
+            ParseResult(
+                persistentListOf(
+                    BD09MCPoint(
+                        3315902.2199999997, 13502918.375,
+                        3.14,
+                        name = "黄岩客运中心",
+                        source = Source.JAVASCRIPT,
+                    )
+                )
+            ),
+            input.parse(
+                // language=Json
+                """
+                    {
+                        "lat": 3315902.2199999997,
+                        "lon": 13502918.375,
+                        "z": 3.14,
+                        "name": "黄岩客运中心"
+                    }
+                """.trimIndent(),
+                "https://map.baidu.com/original",
+                log = FakeLog,
+            ),
         )
+        assertEquals(
+            ParseResult(
+                persistentListOf(
+                    BD09MCPoint(
+                        3315902.2199999997, 13502918.375,
+                        source = Source.JAVASCRIPT,
+                    )
+                )
+            ),
+            input.parse(
+                // language=Json
+                """
+                    {
+                        "lat": 3315902.2199999997,
+                        "lon": 13502918.375
+                    }
+                """.trimIndent(),
+                "https://map.baidu.com/original",
+                log = FakeLog,
+            ),
+        )
+        assertEquals(
+            ParseResult(
+                persistentListOf(
+                    BD09MCPoint(
+                        3315902.2199999997,
+                        source = Source.JAVASCRIPT,
+                    )
+                )
+            ),
+            input.parse(
+                // language=Json
+                """
+                    {
+                        "lat": 3315902.2199999997
+                    }
+                """.trimIndent(),
+                "https://map.baidu.com/original",
+                log = FakeLog,
+            ),
+        )
+        assertEquals(
+            ParseResult(
+                persistentListOf(
+                    BD09MCPoint(source = Source.JAVASCRIPT)
+                )
+            ),
+            input.parse(
+                // language=Json
+                "{}",
+                "https://map.baidu.com/original",
+                log = FakeLog,
+            ),
+        )
+    }
+
+    @Test
+    fun parse_whenDataIsValidJsonButHasUnexpectedPropertyType_returnsEmptyResult() = runTest {
+        for (data in listOf(
+            // language=Json
+            """{"lat":  "spam"}""",
+            // language=Json
+            """[]""",
+            // language=Json
+            """"spam"""",
+            // language=Json
+            "0",
+            // language=Json
+            "null",
+        )) {
+            assertEquals(
+                ParseResult(),
+                input.parse(data, "https://map.baidu.com/original", log = FakeLog),
+            )
+        }
+        assertEquals(
+            ParseResult(),
+            input.parse(
+                // language=Json
+                """{"lat":  "spam"}""",
+                "https://map.baidu.com/original",
+                log = FakeLog,
+            ),
+        )
+        assertEquals(
+            ParseResult(),
+            input.parse(
+                // language=Json
+                "[]",
+                "https://map.baidu.com/original",
+                log = FakeLog,
+            ),
+        )
+    }
+
+    @Test
+    fun parse_whenDataIsInvalidJson_returnsEmptyResult() = runTest {
+        for (data in listOf(
+            "{",
+            """{"trailingComma": 0,}""",
+            "",
+        )) {
+            assertEquals(
+                ParseResult(),
+                input.parse(data, "https://map.baidu.com/original", log = FakeLog),
+            )
+        }
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/inputs/WazeHtmlInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/inputs/WazeHtmlInputTest.kt
@@ -37,7 +37,7 @@ class WazeHtmlInputTest : InputTest {
     }
 
     @Test
-    fun parse_containsInvalidDataCoordinates_returnsNull() = runTest {
+    fun parse_containsInvalidDataCoordinates_returnsEmptyResult() = runTest {
         assertEquals(
             ParseResult(),
             input.parse("""<html><script>{"routing": {"to": {"address":"301 Front St W, Toronto, Ontario, Canada","latLng":{"lat":spam,"lng":spam},"title":"CN Tower"}}}}</script></html>""")
@@ -45,7 +45,7 @@ class WazeHtmlInputTest : InputTest {
     }
 
     @Test
-    fun parse_doesNotContainCoordinates_returnsNull() = runTest {
+    fun parse_doesNotContainCoordinates_returnsEmptyResult() = runTest {
         assertEquals(ParseResult(), input.parse("""<html></html>"""))
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/inputs/YandexMapsHtmlInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/inputs/YandexMapsHtmlInputTest.kt
@@ -31,7 +31,7 @@ class YandexMapsHtmlInputTest : InputTest {
     }
 
     @Test
-    fun parse_doesNotContainCoordinates_returnsNull() = runTest {
+    fun parse_doesNotContainCoordinates_returnsEmptyResult() = runTest {
         assertEquals(ParseResult(), input.parse("""<html></html>"""))
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/42.txt
+++ b/fastlane/metadata/android/en-US/changelogs/42.txt
@@ -1,5 +1,6 @@
 - Added the option to send a point via selected messaging apps.
 - Added the option to save a point to a contact.
+- Fixed Baidu Map location accuracy.
 - Fixed pin display when opening Cartes IGN.
 - Fixed splash screen in dark mode.
 - Improved link sharing workflow by closing GeoShare after opening another map app.


### PR DESCRIPTION
The offset was probably caused by a UI element on the map web page shifting the map view and then the map center was not where the POI was.

Fix it by extracting coordinates from JavaScript state.

Fixes: #375