### PR TITLE
Fix web browsers on result screen and All-In-One Maps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,12 +17,6 @@
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data
-                android:scheme="https"
-                android:host="osmand.net" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
             <data android:scheme="magicearth" />
         </intent>
         <intent>

--- a/app/src/main/java/page/ooooo/geoshare/lib/android/AndroidTools.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/android/AndroidTools.kt
@@ -134,7 +134,6 @@ object AndroidTools {
         PackageNames.SIGNAL,
         PackageNames.TELEGRAM,
         PackageNames.TELEGRAM_FORK,
-        PackageNames.SIGNAL,
         PackageNames.WHATSAPP,
     )
 
@@ -144,7 +143,12 @@ object AndroidTools {
                 packageManager,
                 Intent(Intent.ACTION_VIEW, "geo:".toUri()),
             )) {
-                getOrPut(packageName) { mutableSetOf() }.add(DataType.GEO_URI)
+                if (packageName != PackageNames.CARTES_IGN) {
+                    getOrPut(packageName) { mutableSetOf() }.add(DataType.GEO_URI)
+                } else {
+                    // Replace geo: URIs with HTTPs URLs for Cartes IGN, because it doesn't support geo: URIs well
+                    getOrPut(packageName) { mutableSetOf() }.add(DataType.CARTES_IGN_URL)
+                }
             }
             for (packageName in queryPackageNames(
                 packageManager,
@@ -157,16 +161,6 @@ object AndroidTools {
                 Intent(Intent.ACTION_VIEW, "google.streetview:".toUri()),
             )) {
                 getOrPut(packageName) { mutableSetOf() }.add(DataType.GOOGLE_STREET_VIEW_URI)
-            }
-            for (packageName in queryPackageNames(
-                packageManager,
-                Intent(Intent.ACTION_VIEW, "https://cartes-ign.ign.fr".toUri()),
-            )) {
-                getOrPut(packageName) { mutableSetOf() }.apply {
-                    add(DataType.CARTES_IGN_URL)
-                    // Remove support for geo: URIs from the Cartes IGN app, because it doesn't support these URIs well
-                    remove(DataType.GEO_URI)
-                }
             }
             for (packageName in queryPackageNames(
                 packageManager,

--- a/app/src/main/java/page/ooooo/geoshare/lib/android/PackageNames.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/android/PackageNames.kt
@@ -6,6 +6,7 @@ import page.ooooo.geoshare.lib.formatters.GeoUriFlavor
 import page.ooooo.geoshare.lib.geo.Srs
 
 object PackageNames {
+    const val ALL_IN_ONE = "net.psyberia.offlinemaps"
     const val AMAP = "com.autonavi.minimap"
     const val BAIDU_MAP = "com.baidu.BaiduMap"
     const val CARTES_IGN = "fr.ign.geoportail"
@@ -46,7 +47,8 @@ object PackageNames {
 
     fun getGeoUriFlavor(packageName: String?): GeoUriFlavor =
         when {
-            packageName == AMAP ||
+            packageName == ALL_IN_ONE ||
+                packageName == AMAP ||
                 packageName == HERE_WEGO ||
                 packageName == GOOGLE_MAPS ||
                 packageName == GMAPS_WV ||
@@ -66,7 +68,7 @@ object PackageNames {
             packageName?.startsWith(GARMIN_PREFIX) == true ->
                 GeoUriFlavor(
                     pin = GeoUriFlavor.PinFlavor.COORDS_AND_NAME_IN_Q,
-                    zoom = GeoUriFlavor.ZoomFlavor.NOT_AVAILABLE
+                    zoom = GeoUriFlavor.ZoomFlavor.NOT_AVAILABLE,
                 )
 
             packageName == KOMOOT ->

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/GeoUriInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/GeoUriInput.kt
@@ -21,7 +21,7 @@ import page.ooooo.geoshare.lib.geo.WGS84Point
 object GeoUriInput : UriInput, Input.HasRandomUri {
     private const val NAME_REGEX = """\((.+)\)"""
 
-    override val pattern = Regex("""(geo:$LAT_NUM,$LON_NUM\?q=$LAT_NUM,\s*$LON_NUM|geo:$URI_REST)""")
+    override val pattern = Regex("""(geo:$URI_REST)""")
     override val documentation = InputDocumentation(
         group = InputDocumentationGroup.GEO_URI,
         items = listOf(

--- a/app/src/test/java/page/ooooo/geoshare/lib/inputs/GeoUriUriInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/inputs/GeoUriUriInputTest.kt
@@ -17,6 +17,10 @@ class GeoUriUriInputTest : InputTest {
             "geo:50.123456,-11.123456?q=foo%20bar&z=3.4",
             input.match("geo:50.123456,-11.123456?q=foo%20bar&z=3.4")
         )
+        assertEquals(
+            "geo:52.47254,13.4345?q=52.47254,13.4345(My%20place)",
+            input.match("geo:52.47254,13.4345?q=52.47254,13.4345(My%20place)")
+        )
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/43.txt
+++ b/fastlane/metadata/android/en-US/changelogs/43.txt
@@ -1,0 +1,2 @@
+- Fixed web browsers appearing on the conversion result screen.
+- Fixed the opening of All-In-One Maps.


### PR DESCRIPTION
- Don't accidentally query all apps that support HTTP.
- Support the best geo: URI flavor when opening All-In-One Maps.
- Fix geo: URI input with name in pin.

Fixes: #493