### PR TITLE
Fix CoMaps input with links in text

### DIFF
--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/GeoUriInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/GeoUriInputBehaviorTest.kt
@@ -29,5 +29,23 @@ class GeoUriInputBehaviorTest {
             WGS84Point(45.4786785, 9.2473799, source = Source.URI),
             "geo:0,0?q=45.4786785, 9.2473799",
         )
+
+        // Text with geo: URIs as well as MapsMe URIs; the MapsMe URIs will be ignored
+        testText(
+            WGS84Point(
+                40.7127400, -74.0059965,
+                z = 9.0,
+                name = @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "Nova Iorque",
+                source = Source.URI
+            ),
+            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
+            "Organic Maps: geo:40.7127400,-74.0059965?z=9.0&q=40.7127400,-74.0059965(Nova%20Iorque)\n" +
+                "https://omaps.app/Umse5f0H8a/Nova_Iorque",
+        )
+        testText(
+            WGS84Point(52.0553846, -2.7151898, source = Source.URI),
+            "Follow this link https://comaps.at/ItdwBgeWW1/Hereford or paste these coordinates " +
+                "geo:52.0553846,-2.7151898 into your maps app to see this location.",
+        )
     }
 }

--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/MapsMeInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/MapsMeInputBehaviorTest.kt
@@ -36,7 +36,7 @@ class MapsMeInputBehaviorTest {
                 40.7127405, -74.005997,
                 z = 9.0,
                 name = @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "Nova Iorque",
-                source = Source.HASH
+                source = Source.HASH,
             ),
             "https://omaps.app/Umse5f0H8a/Nova_Iorque",
         )
@@ -53,15 +53,6 @@ class MapsMeInputBehaviorTest {
             "América do Norte, Lancer, Saskatchewan, Canadá\n" +
                 "http://ge0.me/ApYSV0YTAl/América_do_Norte\n" +
                 "(51.000001, -108.999988)",
-        )
-
-        // Text, which will get parsed by GeoUriInput, because it contains a geo: URI that precedes the short link
-        testText(
-            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
-            WGS84Point(40.7127400, -74.0059965, z = 9.0, name = "Nova Iorque", source = Source.URI),
-            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
-            "Organic Maps: geo:40.7127400,-74.0059965?z=9.0&q=40.7127400,-74.0059965(Nova%20Iorque)\n" +
-                "https://omaps.app/Umse5f0H8a/Nova_Iorque",
         )
     }
 }

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/GeoUriInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/GeoUriInput.kt
@@ -37,34 +37,35 @@ class GeoUriInput @Inject constructor(
         data.run {
             val z = Z_PATTERN.matchEntire(queryParams["z"])?.doubleGroupOrNull()
 
-            // Name in separate param
-            // ?q={lat},{lon}&({name})
+            // Name in separate query param
+            // ?q=...&({name})
             val name = queryParams
                 .filter { (key, value) -> key != "q" && key != "z" && value.isEmpty() }
                 .firstNotNullOfOrNull { (key) -> Regex(NAME_REGEX).matchEntire(key)?.groupOrNull() }
-            // Query
-            // ?q={name}
-                ?: Q_PARAM_PATTERN.matchEntire(queryParams["q"])?.groupOrNull()
 
             // Pin without name
             // ?q={lat},{lon}
             // Pin with name
             // ?q={lat},{lon}({name})
-            Regex("""$LAT$COORD_SEP$LON(?:$NAME_REGEX)?""").matchEntire(queryParams["q"])
+            Regex("""$LAT$COORD_SEP$LON(?:$NAME_REGEX)?.*""").matchEntire(queryParams["q"])
                 ?.toLatLonNamePoint(Source.URI)?.let {
                     points = persistentListOf(WGS84Point(it, z, name))
                     return@run
                 }
 
+            // Query unless it contained coordinates
+            // ?q={name}
+            val query = Q_PARAM_PATTERN.matchEntire(queryParams["q"])?.groupOrNull()
+
             // Coordinates
             // geo:{lat},{lon}
-            LAT_LON_PATTERN.matchEntire(pathParts.firstOrNull())?.toLatLonPoint(Source.URI)?.let {
-                points = persistentListOf(WGS84Point(it, z, name))
+            Regex("""$LAT_LON_PATTERN.*""").matchEntire(pathParts.firstOrNull())?.toLatLonPoint(Source.URI)?.let {
+                points = persistentListOf(WGS84Point(it, z, name ?: query))
                 return@run
             }
 
-            if (name != null) {
-                points = persistentListOf(WGS84Point(z = z, name = name, source = Source.URI))
+            if (name != null || query != null) {
+                points = persistentListOf(WGS84Point(z = z, name = name ?: query, source = Source.URI))
             }
         }
     }

--- a/app/src/test/java/page/ooooo/geoshare/lib/inputs/GeoUriUriInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/inputs/GeoUriUriInputTest.kt
@@ -13,7 +13,7 @@ class GeoUriUriInputTest : InputTest {
     private val input = FakeInputRepository.geoUriInput
 
     @Test
-    fun match_valid() {
+    fun match_uri() {
         assertEquals(
             "geo:50.123456,-120.123456?q=foo%20bar&z=3.4",
             input.match("geo:50.123456,-120.123456?q=foo%20bar&z=3.4")
@@ -21,6 +21,26 @@ class GeoUriUriInputTest : InputTest {
         assertEquals(
             "geo:52.47254,13.4345?q=52.47254,13.4345(My%20place)",
             input.match("geo:52.47254,13.4345?q=52.47254,13.4345(My%20place)")
+        )
+    }
+
+    @Test
+    fun match_uriInText() {
+        assertEquals(
+            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
+            "geo:40.7127400,-74.0059965?z=9.0&q=40.7127400,-74.0059965(Nova%20Iorque)",
+            input.match(
+                @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
+                "geo:40.7127400,-74.0059965?z=9.0&q=40.7127400,-74.0059965(Nova%20Iorque)\n" +
+                    "https://omaps.app/Umse5f0H8a/Nova_Iorque"
+            ),
+        )
+        assertEquals(
+            "geo:52.0553846,-2.7151898 into your maps app to see this location.",
+            input.match(
+                "Follow this link https://comaps.at/ItdwBgeWW1/Hereford or paste these coordinates " +
+                    "geo:52.0553846,-2.7151898 into your maps app to see this location."
+            ),
         )
     }
 
@@ -47,19 +67,6 @@ class GeoUriUriInputTest : InputTest {
     @Test
     fun match_unknownPath() {
         assertEquals("geo:example?q=foo%20bar&z=3.4", input.match("geo:example?q=foo%20bar&z=3.4"))
-    }
-
-    @Test
-    fun match_replacement() {
-        assertEquals(
-            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
-            "geo:40.7127400,-74.0059965?z=9.0&q=40.7127400,-74.0059965(Nova%20Iorque)",
-            input.match(
-                @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
-                "geo:40.7127400,-74.0059965?z=9.0&q=40.7127400,-74.0059965(Nova%20Iorque)\n" +
-                    "https://omaps.app/Umse5f0H8a/Nova_Iorque"
-            ),
-        )
     }
 
     @Test
@@ -201,6 +208,18 @@ class GeoUriUriInputTest : InputTest {
         assertEquals(
             ParseResult(persistentListOf(WGS84Point(45.4786785, 9.2473799, source = Source.URI))),
             input.parse("geo:0,0?q=45.4786785,%209.2473799"),
+        )
+    }
+
+    @Test
+    fun parse_coordsWithTrailingGarbage() = runTest {
+        assertEquals(
+            ParseResult(persistentListOf(WGS84Point(52.0553846, -2.7151898, source = Source.URI))),
+            input.parse("geo:52.0553846,-2.7151898 into your maps app to see this location."),
+        )
+        assertEquals(
+            ParseResult(persistentListOf(WGS84Point(52.0553846, -2.7151898, source = Source.URI))),
+            input.parse("geo:0,0?q=52.0553846,-2.7151898 into your maps app to see this location."),
         )
     }
 }

--- a/app/src/test/java/page/ooooo/geoshare/lib/inputs/WazeUriInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/inputs/WazeUriInputTest.kt
@@ -67,6 +67,15 @@ class WazeUriInputTest : InputTest {
     }
 
     @Test
+    fun match_shortLinkInText() {
+        assertEquals(
+            "https://waze.com/ul/hu00uswvn3",
+            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
+            input.match("Use Waze to drive to 5 - 22 Boulevard Gambetta: https://waze.com/ul/hu00uswvn3"),
+        )
+    }
+
+    @Test
     fun match_unknownHost() {
         assertNull(input.match("https://www.example.com/ul?ll=45.6906304,-120.810983&z=10"))
     }
@@ -76,15 +85,6 @@ class WazeUriInputTest : InputTest {
         assertEquals(
             "waze.com/ul?ll=45.6906304,-120.810983&z=10",
             input.match("ftp://waze.com/ul?ll=45.6906304,-120.810983&z=10"),
-        )
-    }
-
-    @Test
-    fun match_replacement() {
-        assertEquals(
-            "https://waze.com/ul/hu00uswvn3",
-            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection")
-            input.match("Use Waze to drive to 5 - 22 Boulevard Gambetta: https://waze.com/ul/hu00uswvn3"),
         )
     }
 

--- a/fastlane/metadata/android/en-US/changelogs/46.txt
+++ b/fastlane/metadata/android/en-US/changelogs/46.txt
@@ -1,2 +1,3 @@
 - Added support for Mapy.com navigation links.
 - Improved result screen by putting messaging apps in their own section.
+- Fixed support for links in text shared from CoMaps.


### PR DESCRIPTION
Allow trailing garbage text in the geo: URI input.

Fixes: #547