### PR TITLE
Show how long to wait if too many requests

### DIFF
--- a/app/src/main/java/page/ooooo/geoshare/lib/network/NetworkException.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/network/NetworkException.kt
@@ -3,6 +3,7 @@ package page.ooooo.geoshare.lib.network
 import android.content.res.Resources
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
+import io.ktor.http.HttpHeaders
 import page.ooooo.geoshare.R
 
 sealed class NetworkException(cause: Throwable) : Exception(cause) {
@@ -16,19 +17,23 @@ sealed class RecoverableNetworkException(cause: Throwable) : NetworkException(ca
 sealed class UnrecoverableNetworkException(cause: Throwable) : NetworkException(cause)
 
 class UnresolvedAddressNetworkException(cause: Throwable) : RecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_unresolved_address)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_unresolved_address)
 }
 
 class RequestTimeoutNetworkException(cause: Throwable) : RecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_request_timeout)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_request_timeout)
 }
 
 class SocketTimeoutNetworkException(cause: Throwable) : RecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_socket_timeout)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_socket_timeout)
 }
 
 class ConnectTimeoutNetworkException(cause: Throwable) : RecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_connect_timeout)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_connect_timeout)
 }
 
 class ConnectionClosedNetworkException(cause: Throwable) : RecoverableNetworkException(cause) {
@@ -36,7 +41,8 @@ class ConnectionClosedNetworkException(cause: Throwable) : RecoverableNetworkExc
 }
 
 class ConnectionRefusedNetworkException(cause: Throwable) : RecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_connect_exception)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_connect_exception)
 }
 
 class ServerResponseNetworkException(val response: HttpResponse, cause: Throwable) :
@@ -54,20 +60,28 @@ class ResponseNetworkException(val response: HttpResponse, cause: Throwable) : U
 
 class TooManyRequestsNetworkException(val response: HttpResponse, cause: Throwable) :
     UnrecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_too_many_requests)
+    override fun getMessage(resources: Resources) =
+        response.headers[HttpHeaders.RetryAfter]
+            ?.toIntOrNull()
+            ?.let { retryAfter ->
+                resources.getString(R.string.network_exception_too_many_requests_wait, retryAfter)
+            }
+            ?: resources.getString(R.string.network_exception_too_many_requests)
 
     override fun getDetails() = "Request URL: ${response.request.url}"
 }
 
 class UnauthorizedNetworkException(val response: HttpResponse, cause: Throwable) :
     UnrecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_unauthorized)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_unauthorized)
 
     override fun getDetails() = "Request URL: ${response.request.url}"
 }
 
 class UnknownNetworkException(cause: Throwable) : UnrecoverableNetworkException(cause) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_unknown)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_unknown)
 
     override fun getDetails() = cause?.stackTraceToString()
 }
@@ -78,5 +92,6 @@ class MissingHeaderNetworkException : UnrecoverableNetworkException(Throwable())
 }
 
 class WebViewNetworkException : RecoverableNetworkException(Throwable()) {
-    override fun getMessage(resources: Resources) = resources.getString(R.string.network_exception_webview)
+    override fun getMessage(resources: Resources) =
+        resources.getString(R.string.network_exception_webview)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,7 @@
     <string name="network_exception_server_response_error">Server response error %1$d</string>
     <string name="network_exception_socket_timeout">Socket timeout</string>
     <string name="network_exception_too_many_requests">Too many requests</string>
+    <string name="network_exception_too_many_requests_wait">Too many requests, wait for %1$ds</string>
     <string name="network_exception_unknown">Unknown error</string>
     <string name="network_exception_unauthorized">Unauthorized</string>
     <string name="network_exception_unresolved_address">Unresolved address</string>

--- a/app/src/test/java/page/ooooo/geoshare/lib/network/NetworkExceptionTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/network/NetworkExceptionTest.kt
@@ -1,0 +1,47 @@
+package page.ooooo.geoshare.lib.network
+
+import android.content.res.Resources
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import page.ooooo.geoshare.R
+
+class NetworkExceptionTest {
+    private val resources: Resources = mock {
+        on { getString(R.string.network_exception_too_many_requests) } doReturn "Too many requests"
+        on {
+            getString(R.string.network_exception_too_many_requests_wait, 120)
+        } doReturn "Too many requests, wait for 120s"
+    }
+
+    @Test
+    fun tooManyRequestsNetworkException_getMessage_whenHeadersContainRetryAfter_returnsMessageWithWaitSeconds() {
+        val response: HttpResponse = mock {
+            on { headers } doReturn headersOf(HttpHeaders.RetryAfter to listOf("120"))
+        }
+        val ex = TooManyRequestsNetworkException(response, Throwable())
+        assertEquals("Too many requests, wait for 120s", ex.getMessage(resources))
+    }
+
+    @Test
+    fun tooManyRequestsNetworkException_getMessage_whenHeadersDoNotContainRetryAfter_returnsMessageWithoutWaitSeconds() {
+        val response: HttpResponse = mock {
+            on { headers } doReturn headersOf()
+        }
+        val ex = TooManyRequestsNetworkException(response, Throwable())
+        assertEquals("Too many requests", ex.getMessage(resources))
+    }
+
+    @Test
+    fun tooManyRequestsNetworkException_getMessage_whenHeadersContainInvalidRetryAfter_returnsMessageWithoutWaitSeconds() {
+        val response: HttpResponse = mock {
+            on { headers } doReturn headersOf(HttpHeaders.RetryAfter to listOf("spam"))
+        }
+        val ex = TooManyRequestsNetworkException(response, Throwable())
+        assertEquals("Too many requests", ex.getMessage(resources))
+    }
+}


### PR DESCRIPTION
### Motivation

Users don't know how rate limiting works, so they might retry when it's pointless, or give up, when a little waiting would be fine.

### Changes

Show a "Too many requests, wait <number>s"

### Remaining issues

no

### Checklist

- [X] Unit tests added or updated (or the PR doesn't contain a testable change)
- [X] Instrumented tests added or updated (or the change is sufficiently covered by other tests)
- [X] Changelog updated (or the PR doesn't contain a user-facing change)
- [X] Metadata screenshots updated (or the PR doesn't change the relevant screens)
- [x] Weblate screenshots updated (or the PR doesn't change translatable texts)