### PR TITLE
Fix Google Maps web parsing timeout

### DIFF
--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/BehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/BehaviorTest.kt
@@ -327,7 +327,7 @@ fun UiAutomatorTestScope.waitAndAssertGoogleMapsContainsElement(block: Accessibi
     onElementOrNull(3_000) {
         packageName == PackageNames.GOOGLE_MAPS && textAsString() in setOf(
             "Make it your map",
-            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "Profitez d'une carte personnalisée"
+            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "Profitez d'une carte personnalisée",
         )
     }?.let {
         onElement {
@@ -369,7 +369,7 @@ fun UiAutomatorTestScope.waitAndAssertTomTomContainsElement(block: Accessibility
     onElementOrNull(5_000) {
         textAsString() in setOf(
             "Got it",
-            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "J'ai compris"
+            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "J'ai compris",
         )
     }?.click()
 
@@ -533,7 +533,7 @@ fun UiAutomatorTestScope.launchNavigationInApp(@Suppress("SameParameterValue") p
     onElement {
         viewIdResourceName == "geoShareAppOutput" && textAsString() in setOf(
             "Navigate",
-            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "Naviguer"
+            @Suppress("GrazieInspectionRunner", "SpellCheckingInspection") "Naviguer",
         )
     }.click()
 }

--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/ConversionBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/ConversionBehaviorTest.kt
@@ -71,8 +71,13 @@ class ConversionBehaviorTest {
         // Tap the Google Maps icon
         clickAppIcon(PackageNames.GOOGLE_MAPS)
 
-        // Google Maps shows precise location (fails on Nexus 5)
-        waitAndAssertGoogleMapsContainsElement { textAsString() == "Ming&Qing Dynasties Furniture Hall" }
+        // Google Maps shows precise location
+        waitAndAssertGoogleMapsContainsElement {
+            textAsString() in setOf(
+                "Ming&Qing Dynasties Furniture Hall",
+                """31°13'42.6"N 121°28'31.9"E""", // Sometimes shown on Nexus 5 instead of place name
+            )
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/ConversionBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/ConversionBehaviorTest.kt
@@ -2,7 +2,6 @@ package page.ooooo.geoshare.tests
 
 import androidx.test.uiautomator.Direction
 import androidx.test.uiautomator.UiAutomatorTestScope
-import androidx.test.uiautomator.scrollToElement
 import androidx.test.uiautomator.textAsString
 import androidx.test.uiautomator.uiAutomator
 import kotlinx.coroutines.Dispatchers
@@ -324,6 +323,8 @@ class ConversionBehaviorTest {
 
     @Test
     fun opensGoogleMapsSearchLink() = uiAutomator {
+        assumeAppInstalled(PackageNames.GOOGLE_MAPS)
+
         // Launch application and close intro
         launchApplication()
         waitForAppToBeVisible()
@@ -335,10 +336,9 @@ class ConversionBehaviorTest {
 
         // Click the link
         onMainScrollablePane()
-            .scrollToElement(Direction.DOWN, timeoutMs = 3_000) {
-                viewIdResourceName == "geoShareApp_${InitialLinks.GOOGLE_MAPS_DISPLAY_UUID}"
-            }
-            .longClick()
+            // Scroll by percents, because it's more reliable than scrolling to the app icon
+            .scroll(Direction.DOWN, 2f)
+        onElement { viewIdResourceName == "geoShareApp_${InitialLinks.GOOGLE_MAPS_DISPLAY_UUID}" }.longClick()
         onElement {
             viewIdResourceName == "geoShareAppOutput" && textAsString()?.contains("Google Maps search") == true
         }.click()

--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/InputsBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/InputsBehaviorTest.kt
@@ -1,5 +1,7 @@
 package page.ooooo.geoshare.tests
 
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.scrollToElement
 import androidx.test.uiautomator.uiAutomator
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -76,7 +78,13 @@ class InputsBehaviorTest {
         goToInputList()
 
         // Shows documentations added since version 19
-        onElement { viewIdResourceName == "geoShareInputsDocumentationRecent_${InputDocumentationGroup.HERE_WEGO}" }
-        onElement { viewIdResourceName == "geoShareInputsDocumentationRecent_${InputDocumentationGroup.MAGIC_EARTH}" }
+        onElement { viewIdResourceName == "geoShareInputListPane" }.apply {
+            scrollToElement(Direction.DOWN) {
+                viewIdResourceName == "geoShareInputsDocumentationRecent_${InputDocumentationGroup.HERE_WEGO}"
+            }
+            scrollToElement(Direction.DOWN) {
+                viewIdResourceName == "geoShareInputsDocumentationRecent_${InputDocumentationGroup.MAGIC_EARTH}"
+            }
+        }
     }
 }

--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/GoogleMapsAddressApiInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/GoogleMapsAddressApiInputBehaviorTest.kt
@@ -120,7 +120,7 @@ class GoogleMapsAddressApiInputBehaviorTest(private val testServerParams: TestSe
             },
         )
 
-        // Short links with coordinates in HTML (fails on Nexus 5)
+        // Short links with coordinates in HTML
         testUri(
             if (testServer is TestServer.Configured) {
                 WGS84Point(

--- a/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/GoogleMapsInputBehaviorTest.kt
+++ b/app/src/androidTest/java/page/ooooo/geoshare/tests/inputs/GoogleMapsInputBehaviorTest.kt
@@ -164,7 +164,6 @@ class GoogleMapsInputBehaviorTest {
         configureConnectionPermissionPreference(Permission.ALWAYS)
 
         if (htmlParsingSupported) {
-            // Fails on Nexus 5
             testUri(
                 persistentListOf(
                     WGS84Point(

--- a/app/src/androidTestFree/java/page/ooooo/geoshare/tests/ConversionFreeBehaviorTest.kt
+++ b/app/src/androidTestFree/java/page/ooooo/geoshare/tests/ConversionFreeBehaviorTest.kt
@@ -62,7 +62,7 @@ class ConversionFreeBehaviorTest {
                 confirmDialog()
             }
 
-            // Shows precise location (fails on Nexus 5)
+            // Shows precise location
             assertConversionSucceeds(
                 GCJ02Point(
                     52.4834254, 13.4245399,

--- a/app/src/androidTestFree/java/page/ooooo/geoshare/tests/LinkBehaviorTest.kt
+++ b/app/src/androidTestFree/java/page/ooooo/geoshare/tests/LinkBehaviorTest.kt
@@ -44,8 +44,10 @@ class LinkBehaviorTest {
             .scroll(Direction.DOWN, 2f)
         onElement { viewIdResourceName == "geoShareAppLabel" && textAsString() == "My New Maps" }.longClick()
         onElement {
-            viewIdResourceName == "geoShareAppOutput" &&
-                textAsString() in setOf("Copy My New Maps link", "Copier le lien My New Maps")
+            viewIdResourceName == "geoShareAppOutput" && textAsString() in setOf(
+                "Copy My New Maps link",
+                "Copier le lien My New Maps",
+            )
         }.click()
 
         // Shows success message

--- a/app/src/free/java/page/ooooo/geoshare/lib/inputs/GoogleMapsPlaceListInputImpl.kt
+++ b/app/src/free/java/page/ooooo/geoshare/lib/inputs/GoogleMapsPlaceListInputImpl.kt
@@ -45,7 +45,7 @@ class GoogleMapsPlaceListInputImpl @Inject constructor(
      * ```
      */
     // language=JavaScript
-    override val unsafeExtractionJavascript = $$"""
+    override fun getUnsafeExtractionJavaScript(match: String) = $$"""
         () => {
             function findPointsInAppInitState(obj) {
                 const MAX_PRECISION = 17;

--- a/app/src/free/java/page/ooooo/geoshare/lib/inputs/GoogleMapsWebViewInput.kt
+++ b/app/src/free/java/page/ooooo/geoshare/lib/inputs/GoogleMapsWebViewInput.kt
@@ -1,9 +1,7 @@
 package page.ooooo.geoshare.lib.inputs
 
-import android.util.Log
 import android.webkit.WebSettings
 import androidx.annotation.StringRes
-import org.json.JSONObject
 import page.ooooo.geoshare.R
 import page.ooooo.geoshare.lib.network.DESKTOP_USER_AGENT
 import javax.inject.Inject
@@ -20,13 +18,23 @@ class GoogleMapsWebViewInput @Inject constructor(
     override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
 
     /**
-     * Extracts the URL of the page, but only if the JavaScript of the page has changed the URL.
+     * Extracts the URL of the page.
      *
-     * TODO Document why startsWith()
+     * Returns undefined if the URL doesn't contain coordinates, so that the extraction is retried until the page
+     * JavaScript changes the URL into one with coordinates.
+     *
+     * The check whether the URL contains coordinates is very simple, because we don't want to reimplement the whole URI
+     * parsing here, and because we know that:
+     *
+     * - The URL will most probably be in format `/@{lat},{lon},{z}z`
+     * - The URL could plausibly be in format `/data=...!3d{lat}!4d{lon}`
+     * - The URL is unlikely to be in another format such as `/?ll={lat},{lon}`
      */
     // language=JavaScript
     override fun getUnsafeExtractionJavaScript(match: String) = """
-        () => !location.href.startsWith(${JSONObject.quote(match)}) ? location.href : undefined;
+        () => location.href.includes("/@") || location.href.includes("!2d") || location.href.includes("!4d")
+            ? location.href
+            : undefined;
     """.trimIndent()
 
     override suspend fun parse(data: String, match: String) = parseResult {

--- a/app/src/free/java/page/ooooo/geoshare/lib/inputs/GoogleMapsWebViewInput.kt
+++ b/app/src/free/java/page/ooooo/geoshare/lib/inputs/GoogleMapsWebViewInput.kt
@@ -1,7 +1,9 @@
 package page.ooooo.geoshare.lib.inputs
 
+import android.util.Log
 import android.webkit.WebSettings
 import androidx.annotation.StringRes
+import org.json.JSONObject
 import page.ooooo.geoshare.R
 import page.ooooo.geoshare.lib.network.DESKTOP_USER_AGENT
 import javax.inject.Inject
@@ -18,25 +20,13 @@ class GoogleMapsWebViewInput @Inject constructor(
     override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
 
     /**
-     * Extracts the final URL of the page.
+     * Extracts the URL of the page, but only if the JavaScript of the page has changed the URL.
      *
-     * When the extraction is first called, it remembers the URL of the page. Then if in a subsequent extraction call
-     * the URL is different, it returns the new URL. This way we wait for the JavaScript of the page to change the URL
-     * and don't erroneously consider the extraction done before the JavaScript fully ran.
+     * TODO Document why startsWith()
      */
     // language=JavaScript
-    override val unsafeExtractionJavascript = """
-        () => {
-            const url = window.location.href;
-            if (url !== 'about:blank') {
-                if (window.__firstUrl === undefined) {
-                    window.__firstUrl = url;
-                } else if (window.__firstUrl !== url) {
-                    return url;
-                }
-            }
-            return undefined;
-        };
+    override fun getUnsafeExtractionJavaScript(match: String) = """
+        () => !location.href.startsWith(${JSONObject.quote(match)}) ? location.href : undefined;
     """.trimIndent()
 
     override suspend fun parse(data: String, match: String) = parseResult {
@@ -86,6 +76,5 @@ class GoogleMapsWebViewInput @Inject constructor(
 
                 // Something that is requested too many times
                 || requestUrlString.contains("/maps/res/CompactLegend-Roadmap-")
-
     }
 }

--- a/app/src/main/java/page/ooooo/geoshare/lib/conversion/ConversionState.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/conversion/ConversionState.kt
@@ -302,7 +302,7 @@ data class PermissionGrantedBasicInput<T>(
  * When this state is the current state, the UI should:
  *
  * 1. Load [matchedInput]'s match as a page URL in a WebView.
- * 2. Call [WebViewInput.unsafeExtractionJavascript] periodically.
+ * 2. Get JavaScript code using [WebViewInput.getUnsafeExtractionJavaScript] and call it periodically.
  * 3. Once the result of the extraction JavaScript stops changing, complete [pendingData].
  *
  * When it fails, it retries up to [maxAttempts] times. Retrying is done by recursively transitioning this state while

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/BaiduMapWebViewInput.kt
@@ -31,7 +31,7 @@ class BaiduMapWebViewInput @Inject constructor(
      * Notice that we don't take coordinates from `_appStateFromUrl.loc`, because these have a longitude offset.
      */
     // language=JavaScript
-    override val unsafeExtractionJavascript = """
+    override fun getUnsafeExtractionJavaScript(match: String) = """
         () => {
             function deepGet(obj, ...keys) {
                 return keys.reduce((acc, key) => {

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/DebugWebViewInput.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/DebugWebViewInput.kt
@@ -20,8 +20,8 @@ class DebugWebViewInput @Inject constructor() : WebViewInput {
     override val loadingIndicatorTitleResId = R.string.converter_debug_loading_indicator_title
 
     // language=JavaScript
-    override val unsafeExtractionJavascript = """
-        () => window.location.href !== 'about:blank' ? window.location.href : undefined;
+    override fun getUnsafeExtractionJavaScript(match: String) = """
+        () => location.href;
     """.trimIndent()
 
     override suspend fun parse(data: String, match: String) = parseResult {

--- a/app/src/main/java/page/ooooo/geoshare/lib/inputs/Input.kt
+++ b/app/src/main/java/page/ooooo/geoshare/lib/inputs/Input.kt
@@ -42,7 +42,8 @@ interface BasicInput<T> : Input {
  */
 interface WebViewInput : Input, Input.HasPermission {
     val timeout: Duration get() = 60.seconds
-    val unsafeExtractionJavascript: String
+
+    fun getUnsafeExtractionJavaScript(match: String): String
 
     suspend fun parse(data: String, match: String): ParseResult
 

--- a/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/MainScreen.kt
@@ -952,8 +952,8 @@ private fun MainWebView(
         )
         ConversionWebView(
             unsafeUrl = matchedInput.match,
-            unsafeExtractionJavascript = matchedInput.input.unsafeExtractionJavascript,
-            pendingData = pendingData,
+            unsafeExtractionJavascript = matchedInput.input.getUnsafeExtractionJavaScript(matchedInput.match),
+            pendingExtractionResult = pendingData,
             extendWebSettings = { matchedInput.input.extendWebSettings(it) },
             shouldInterceptRequest = { matchedInput.input.shouldInterceptRequest(it) },
         )

--- a/app/src/main/java/page/ooooo/geoshare/ui/components/ConversionWebView.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/components/ConversionWebView.kt
@@ -33,12 +33,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.onEach
 import page.ooooo.geoshare.lib.network.WebViewNetworkException
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+private const val JAVA_SCRIPT_INTERFACE_NAME = "Android"
 private const val TAG = "ConversionWebView"
 
 @OptIn(FlowPreview::class)
@@ -47,7 +47,7 @@ private const val TAG = "ConversionWebView"
 fun ConversionWebView(
     unsafeUrl: String,
     unsafeExtractionJavascript: String,
-    pendingData: CompletableDeferred<String>,
+    pendingExtractionResult: CompletableDeferred<String>,
     extendWebSettings: (settings: WebSettings) -> Unit,
     shouldInterceptRequest: (requestUrlString: String) -> Boolean,
     // Set window size minus a common browser chrome size, so the numbers seem real, in case a web page checks
@@ -72,25 +72,23 @@ fun ConversionWebView(
     val safeUrl = remember(unsafeUrl) {
         allowedUrlPatterns.firstNotNullOfOrNull { pattern -> Regex(pattern).matchEntire(unsafeUrl)?.value }
     }
+    val extractionResultFlow = remember(safeUrl) { MutableStateFlow<String?>(null) }
 
-    // Store the extraction result. Then call the extraction settle callback. Call it only after the result hasn't
-    // changed in a while, because:
-    // 1. The first extraction often doesn't lead to the final result. For example when extracting the page URL, the
-    //    first URL is not the final one. It can take the page a few seconds to set the final page URL.
-    // 2. Quick calls to the settle callback would make a ConversionState transition crash, because each new transition
-    //    cancels any running transition.
-    val dataFlow = remember(safeUrl) { MutableStateFlow<String?>(null) }
-    LaunchedEffect(dataFlow) {
-        dataFlow
+    /**
+     * Stores the extraction result by completing the [pendingExtractionResult] deferred variable.
+     *
+     * It stores the result only after it hasn't changed in a while, because the first extraction often doesn't lead to
+     * the final result. For example when extracting the page URL, the first URL is not the final one. It can take the
+     * page JavaScript a few seconds to set the final page URL.
+     */
+    LaunchedEffect(extractionResultFlow) {
+        extractionResultFlow
             .filterNotNull()
-            .onEach { data ->
-                Log.d(TAG, "Extracted $data")
-            }
             .distinctUntilChanged()
             .debounce(settleTimeout)
-            .collect { data ->
-                Log.i(TAG, "Extraction settled at $data after $settleTimeout")
-                pendingData.complete(data)
+            .collect { extractionResult ->
+                Log.i(TAG, "Extraction settled at $extractionResult")
+                pendingExtractionResult.complete(extractionResult)
             }
     }
 
@@ -135,8 +133,10 @@ fun ConversionWebView(
                 extendWebSettings(settings)
 
                 webChromeClient = object : WebChromeClient() {
-                    override fun onConsoleMessage(cm: ConsoleMessage): Boolean =
-                        // Return true for messages that should be excluded from logcat
+                    /**
+                     * Returns true for messages that should be excluded from logcat
+                     */
+                    override fun onConsoleMessage(cm: ConsoleMessage) =
                         (cm.messageLevel() != ConsoleMessage.MessageLevel.ERROR &&
                             cm.messageLevel() != ConsoleMessage.MessageLevel.WARNING) ||
                             cm.message().startsWith("Mixed Content")
@@ -146,21 +146,25 @@ fun ConversionWebView(
                     object {
                         @Suppress("unused")
                         @JavascriptInterface
-                        fun onExtractSuccess(data: String) {
-                            dataFlow.value = data
+                        fun onExtractSuccess(extractionResult: String) {
+                            Log.d(TAG, "Extracted $extractionResult")
+                            extractionResultFlow.value = extractionResult
                         }
 
                         @Suppress("unused")
                         @JavascriptInterface
                         fun onExtractFailure() {
-                            Log.w(TAG, "Extraction failure")
-                            pendingData.completeExceptionally(WebViewNetworkException())
+                            Log.w(TAG, "Extraction failed")
+                            pendingExtractionResult.completeExceptionally(WebViewNetworkException())
                         }
                     },
-                    "Android",
+                    JAVA_SCRIPT_INTERFACE_NAME,
                 )
 
                 webViewClient = object : WebViewClient() {
+                    /**
+                     * Runs extraction repeatedly every [extractionInterval]
+                     */
                     override fun onPageFinished(view: WebView?, url: String?) {
                         super.onPageFinished(view, url)
 
@@ -169,19 +173,27 @@ fun ConversionWebView(
                             """
                                 (() => {
                                     const extract = $unsafeExtractionJavascript;
-                                    window.setInterval(
-                                        () => {
-                                            if (location.protocol === 'chrome-error:') {
-                                                Android.onExtractFailure();
-                                            } else {
-                                                const data = extract();
-                                                if (data !== null && data !== undefined) {
-                                                    Android.onExtractSuccess(data);
-                                                }
+                                    function extractAndCallback() {
+                                        try {
+                                            switch (location.protocol) {
+                                                case 'about:':
+                                                    // Try again if the page is about:blank
+                                                    break;
+                                                case 'chrome-error:':
+                                                    $JAVA_SCRIPT_INTERFACE_NAME.onExtractFailure();
+                                                    break;
+                                                default:
+                                                    const extractionResult = extract();
+                                                    if (extractionResult !== null && extractionResult !== undefined) {
+                                                        $JAVA_SCRIPT_INTERFACE_NAME.onExtractSuccess(extractionResult);
+                                                    }
                                             }
-                                        },
-                                        ${extractionInterval.inWholeMilliseconds}
-                                    );
+                                        } catch (ex) {
+                                            console.error("Extraction exception", ex);
+                                        }
+                                    }
+                                    extractAndCallback();
+                                    window.setInterval(extractAndCallback, ${extractionInterval.inWholeMilliseconds});
                                 })();
                             """.trimIndent(),
                             null,
@@ -194,10 +206,9 @@ fun ConversionWebView(
                     ): WebResourceResponse? {
                         request?.url?.toString()?.let { requestUrlString ->
                             if (shouldInterceptRequest(requestUrlString)) {
-                                Log.d(TAG, "Blocked request $requestUrlString")
                                 return WebResourceResponse("text/plain", "utf-8", null)
                             }
-                            Log.d(TAG, "Allowed request $requestUrlString")
+                            // In development, you can log requests with Log.d(TAG, "Allowed request $requestUrlString")
                         }
                         return super.shouldInterceptRequest(view, request)
                     }
@@ -210,27 +221,34 @@ fun ConversionWebView(
         },
         modifier = Modifier.requiredSize(size),
         update = { webView ->
-            if (safeUrl != null && webView.url != safeUrl) {
-                webView.loadUrl(safeUrl)
+            webView.apply {
+                if (safeUrl != null && url != safeUrl) {
+                    loadUrl(safeUrl)
+                }
             }
         },
         onReset = { webView ->
-            webView.stopLoading()
-            webView.loadUrl("about:blank")
-            webView.clearHistory()
+            webView.apply {
+                clearHistory()
+            }
         },
         onRelease = { webView ->
-            webView.stopLoading()
+            webView.apply {
+                webView.stopLoading()
 
-            // Neutralize callbacks before any teardown
-            webView.webViewClient = WebViewClient()
-            webView.webChromeClient = null
-            webView.removeJavascriptInterface("Android")
+                // Neutralize callbacks before any teardown
+                webView.webViewClient = WebViewClient()
+                webView.webChromeClient = null
+                webView.removeJavascriptInterface("Android")
 
-            webView.onPause()
-            webView.pauseTimers()
-            webView.removeAllViews()
-            webView.destroy()
+                // Destroy the WebView but don't call pauseTimers(), because that for some reason causes the page to not
+                // load properly when later recreating the WebView. This behavior has been observed and is also
+                // described here: https://stackoverflow.com/a/17458577.
+                // TODO Add instrumented test for WebView recreation
+                webView.onPause()
+                webView.removeAllViews()
+                webView.destroy()
+            }
         },
     )
 }

--- a/app/src/main/java/page/ooooo/geoshare/ui/components/ConversionWebView.kt
+++ b/app/src/main/java/page/ooooo/geoshare/ui/components/ConversionWebView.kt
@@ -234,20 +234,22 @@ fun ConversionWebView(
         },
         onRelease = { webView ->
             webView.apply {
-                webView.stopLoading()
+                // Destroy the WebView to stop it making network connections in the background and to free memory. Some
+                // of the method calls might be unnecessary, but we do it all just it case. Notice that we don't call
+                // pauseTimers(), because that for some reason causes the page to not load properly when recreating the
+                // WebView later. We have observed this behavior, and it is also described at
+                // https://stackoverflow.com/a/17458577.
+
+                stopLoading()
 
                 // Neutralize callbacks before any teardown
-                webView.webViewClient = WebViewClient()
-                webView.webChromeClient = null
-                webView.removeJavascriptInterface("Android")
+                webViewClient = WebViewClient()
+                webChromeClient = null
+                removeJavascriptInterface("Android")
 
-                // Destroy the WebView but don't call pauseTimers(), because that for some reason causes the page to not
-                // load properly when later recreating the WebView. This behavior has been observed and is also
-                // described here: https://stackoverflow.com/a/17458577.
-                // TODO Add instrumented test for WebView recreation
-                webView.onPause()
-                webView.removeAllViews()
-                webView.destroy()
+                onPause()
+                removeAllViews()
+                destroy()
             }
         },
     )

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/PermissionGrantedTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/PermissionGrantedTest.kt
@@ -41,7 +41,8 @@ class PermissionGrantedTest {
         val input = object : WebViewInput {
             override val permissionTitleResId = R.string.converter_google_maps_permission_title
             override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
-            override val unsafeExtractionJavascript = "undefined"
+
+            override fun getUnsafeExtractionJavaScript(match: String) = "undefined"
 
             override suspend fun parse(
                 data: String,

--- a/app/src/test/java/page/ooooo/geoshare/lib/conversion/PermissionGrantedWebViewInputTest.kt
+++ b/app/src/test/java/page/ooooo/geoshare/lib/conversion/PermissionGrantedWebViewInputTest.kt
@@ -44,7 +44,8 @@ class PermissionGrantedWebViewInputTest {
         override val permissionTitleResId = R.string.converter_google_maps_permission_title
         override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
         override val timeout = 7.seconds
-        override val unsafeExtractionJavascript = "undefined"
+
+        override fun getUnsafeExtractionJavaScript(match: String) = "undefined"
 
         override suspend fun parse(data: String, match: String) =
             result.copy(next = next.copy(match = data)) // Store data in MatchedInput, so we can test it
@@ -254,7 +255,8 @@ class PermissionGrantedWebViewInputTest {
             override val permissionTitleResId = R.string.converter_google_maps_permission_title
             override val loadingIndicatorTitleResId = R.string.converter_google_maps_loading_indicator_title
             override val timeout = 7.seconds
-            override val unsafeExtractionJavascript = "undefined"
+
+            override fun getUnsafeExtractionJavaScript(match: String) = "undefined"
 
             override suspend fun parse(data: String, match: String) =
                 throw CancellationException()

--- a/fastlane/metadata/android/en-US/changelogs/47.txt
+++ b/fastlane/metadata/android/en-US/changelogs/47.txt
@@ -1,2 +1,3 @@
 - Added preference to choose when the app should automatically close itself.
-- Fixed support for OpenStreetMap links with pin.
+- Fixed Google Maps timeout.
+- Fixed OpenStreetMap links with pin.


### PR DESCRIPTION
### Motivation

Sharing a second Google Maps link that requires web parsing results in a timeout error. When closing the app between sharing the first and second link, no timeout happens.

Fixes: #549

### Changes

Don't call `pauseTimers()` when releasing WebView, because then when recreating the WebView, the page doesn't load properly for some reason.

### Remaining issues

no

### Checklist

- [X] Unit tests added or updated (or the PR doesn't contain a testable change)
- [X] Instrumented tests added or updated (or the change is sufficiently covered by other tests)
- [X] Changelog updated (or the PR doesn't contain a user-facing change)
- [X] Metadata screenshots updated (or the PR doesn't change the relevant screens)
- [X] Weblate screenshots updated (or the PR doesn't change translatable texts)